### PR TITLE
user-guide.rst: fix non-working code example - add parens

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -594,7 +594,7 @@ methods using the same object:
 
     (flexmock(HTTP)
         .should_receive('get_url.parse_html')
-        .and_return(flexmock, display_results='ok', save_results='ok'))
+        .and_return(flexmock(display_results='ok', save_results='ok')))
 
 
 Replacing methods


### PR DESCRIPTION
I believe the code example cannot work due to a typo - parentheses were omitted. Fix this.