### PR TITLE
Pytest hook: ensure original exception isn't suppressed

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1236,7 +1236,7 @@ def _hook_into_pytest():
             else:
                 teardown = runner.CallInfo(flexmock_teardown, when=when)
                 teardown.result = None
-            if ret.excinfo is not None and teardown.excinfo is None:
+            if ret.excinfo is not None:
                 teardown.excinfo = ret.excinfo
             return teardown
         runner.call_runtest_hook = call_runtest_hook


### PR DESCRIPTION
Hey @bkabrda, I believe this fixes the pytest teardown issue described in https://github.com/bkabrda/flexmock/issues/21. I haven't checked to see if this is consistent with Flexmock's behaviour on non-pytest test runners, but I think it makes sense to show the original error rather than the MethodCallError.
