### PR TITLE
Don't hide exception when flexmock is used as context manager

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -686,7 +686,7 @@ class Mock(object):
         return self._object
 
     def __exit__(self, type, value, traceback):
-        return self
+        pass
 
     def __call__(self, *kargs, **kwargs):
         """Hack to make Expectation.mock() work with parens."""


### PR DESCRIPTION
This relates to bkabrda/flexmock#20.

From Python 3 documentation of __exit__:

If an exception is supplied, and the method wishes to suppress the
exception (i.e., prevent it from being propagated), it should return a
true value. Otherwise, the exception will be processed normally upon
exit from this method.