### PR TITLE
Make _hook_into_pytest() work with pytest-4.1

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1224,8 +1224,11 @@ def _hook_into_pytest():
             ret = saved(item, when, **kwargs)
             if when != 'call' and ret.excinfo is None:
                 return ret
-            teardown = runner.CallInfo(flexmock_teardown, when=when)
-            teardown.result = None
+            if hasattr(runner.CallInfo, "from_call"):
+                teardown = runner.CallInfo.from_call(flexmock_teardown, when=when)
+            else:
+                teardown = runner.CallInfo(flexmock_teardown, when=when)
+                teardown.result = None
             if ret.excinfo is not None and teardown.excinfo is None:
                 teardown.excinfo = ret.excinfo
             return teardown


### PR DESCRIPTION
runner.CallInfo.from_call() was added with
https://github.com/pytest-dev/pytest/commit/847eacea19a02887fb6e63601908a37d7c2576a8

Fixes #27