### PR TITLE
Correct encoding name in flexmock_test.py

### DIFF
--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from flexmock import EXACTLY
 from flexmock import AT_LEAST
 from flexmock import AT_MOST


### PR DESCRIPTION
Emacs complains it should be utf-8 with the hyphen. The examples in [PEP-263](https://www.python.org/dev/peps/pep-0263/) also use "utf-8". And docs/conf.py also uses "utf-8".