### PR TITLE
Fix staticmethod mocking in cpython 2.7

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -29,6 +29,7 @@ __version__ = '0.10.4'
 
 
 import inspect
+import platform
 import re
 import sys
 import types
@@ -662,7 +663,9 @@ class Expectation(object):
                         type(_mock.__dict__) is dict):
                     _mock.__dict__[name] = original
                 else:
-                    if self.method_type == staticmethod and sys.version_info < (3, 0):
+                    if (self.method_type == staticmethod and
+                        sys.version_info < (3, 0) and
+                        platform.python_implementation() != 'CPython'):
                         # on some Python 2 implementations (e.g. pypy), just assigning
                         # the original staticmethod would make it a normal method,
                         # thus an additional "self" argument would be passed to it,

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -966,6 +966,16 @@ class RegularClass(object):
         self._tear_down()
         assertEqual('ok!', User.get_stuff())
 
+    def test_flexmock_should_properly_restore_static_methods_newstyle(self):
+        class User(object):
+            @staticmethod
+            def get_stuff(): return 'ok!'
+        assertEqual('ok!', User.get_stuff())
+        flexmock(User).should_receive('get_stuff')
+        assert User.get_stuff() is None
+        self._tear_down()
+        assertEqual('ok!', User.get_stuff())
+
     def test_flexmock_should_properly_restore_undecorated_static_methods(self):
         class User:
             def get_stuff(): return 'ok!'

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from flexmock import EXACTLY
 from flexmock import AT_LEAST
 from flexmock import AT_MOST


### PR DESCRIPTION
This should fix [issue 31](https://github.com/bkabrda/flexmock/issues/31), but I haven't tested it on other versions of python. Nor do I know the history of the if check.