### PR TITLE
Fix --durations flag when flexmock is installed

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1233,6 +1233,7 @@ def _hook_into_pytest():
                 return ret
             if hasattr(runner.CallInfo, "from_call"):
                 teardown = runner.CallInfo.from_call(flexmock_teardown, when=when)
+                teardown.duration = ret.duration
             else:
                 teardown = runner.CallInfo(flexmock_teardown, when=when)
                 teardown.result = None


### PR DESCRIPTION
If you have this package installed. `pytest --durations` will always report 0s for the call time of a function.