### PR TITLE
Fix flexmock broken with Pytest 4 & 5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,14 @@ Types of changes:
 - **Infrastructure**: Changes in build or deployment infrastructure.
 - **Documentation**: Changes in documentation.
 
+Release 0.10.6
+--------------
+
+Fixed
+#####
+
+- Fix flexmock broken with Pytest 4 & 5.
+
 Release 0.10.5
 --------------
 

--- a/flexmock.py
+++ b/flexmock.py
@@ -1246,7 +1246,9 @@ def _hook_into_pytest():
                 return ret
             if hasattr(runner.CallInfo, "from_call"):
                 teardown = runner.CallInfo.from_call(flexmock_teardown, when=when)
-                teardown.duration = ret.duration
+                if hasattr(runner.CallInfo, "duration"):
+                    # CallInfo.duration only available in Pytest 6+
+                    teardown.duration = ret.duration
             else:
                 teardown = runner.CallInfo(flexmock_teardown, when=when)
                 teardown.result = None


### PR DESCRIPTION
CallInfo.duration was introduced in Pytest 6. Set Callinfo.duration only if it is available.

Closes #46 