### PR TITLE
Fix new_instances not working with Python 2.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ Fixed
 #####
 
 - Fix flexmock broken with Pytest 4 & 5.
+- Fix new_instances method not working with Python 2.7.
 
 Release 0.10.5
 --------------

--- a/flexmock.py
+++ b/flexmock.py
@@ -847,7 +847,11 @@ class Mock(object):
             if method_type in SPECIAL_METHODS:
                 expectation.original_function = getattr(obj, name)
             expectation.method_type = method_type
-        if not _isclass(obj) or expectation.method_type in SPECIAL_METHODS:
+        if (
+            not _isclass(obj)
+            or expectation.method_type in SPECIAL_METHODS
+            or name == '__new__'
+        ):
             method_instance = types.MethodType(method_instance, obj)
         override = _setattr(obj, name, method_instance)
         expectation._local_override = override

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PYTHON_IMPLEMENTATIONS=${PYTHON_IMPLEMENTATIONS:-"python pypy jython"}
-python_VERSIONS=${PYTHON_VERSIONS:-"2.7 3.3 3.4 3.5"}
+python_VERSIONS=${PYTHON_VERSIONS:-"2.7 3.3 3.4 3.5 3.6 3.7 3.8 3.9"}
 pypy_VERSIONS=${PYPY_VERSIONS:-"nover 3"}
 jython_VERSIONS=${JYTHON_VERSIONS:-"nover"}
 


### PR DESCRIPTION
Closes #50 