### PR TITLE
Fix multiple expectations for the same classmethod are not matched (0.10.x)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Fixed
 
 - Fix flexmock broken with Pytest 4 & 5.
 - Fix new_instances method not working with Python 2.7.
+- Fix multiple expectations for the same classmethod are not matched.
 
 Release 0.10.5
 --------------

--- a/flexmock.py
+++ b/flexmock.py
@@ -33,7 +33,6 @@ import re
 import sys
 import types
 
-
 AT_LEAST = 'at least'
 AT_MOST = 'at most'
 EXACTLY = 'exactly'
@@ -834,19 +833,22 @@ class Mock(object):
     def _update_method(self, expectation, name):
         method_instance = self._create_mock_method(name)
         obj = self._object
-        if _hasattr(obj, name) and not hasattr(expectation, 'original'):
-            expectation._update_original(name, obj)
-            method_type = type(_getattr(expectation, 'original'))
-            try:
-                # TODO(herman): this is awful, fix this properly.
-                # When a class/static method is mocked out on an *instance*
-                # we need to fetch the type from the class
-                method_type = type(_getattr(obj.__class__, name))
-            except:
-                pass
-            if method_type in SPECIAL_METHODS:
-                expectation.original_function = getattr(obj, name)
-            expectation.method_type = method_type
+        if _hasattr(obj, name):
+            if hasattr(expectation, 'original'):
+                expectation.method_type = type(_getattr(expectation, 'original'))
+            else:
+                expectation._update_original(name, obj)
+                method_type = type(_getattr(expectation, 'original'))
+                try:
+                    # TODO(herman): this is awful, fix this properly.
+                    # When a class/static method is mocked out on an *instance*
+                    # we need to fetch the type from the class
+                    method_type = type(_getattr(obj.__class__, name))
+                except:
+                    pass
+                if method_type in SPECIAL_METHODS:
+                    expectation.original_function = getattr(obj, name)
+                expectation.method_type = method_type
         if (
             not _isclass(obj)
             or expectation.method_type in SPECIAL_METHODS

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -32,6 +32,18 @@ def module_level_function(some, args):
 
 module_level_attribute = 'test'
 
+class SomeClass:
+    @classmethod
+    def class_method(cls, a):
+        pass
+
+    @staticmethod
+    def static_method(a):
+        pass
+
+    def instance_method(self, a):
+        pass
+
 
 class OldStyleClass:
     pass
@@ -544,6 +556,27 @@ class RegularClass(object):
         flexmock(User).should_call('bar').once()
         assertEqual('value', user1.bar())
 
+    def test_with_args_on_class_mock(self):
+        # Instance method
+        flexmock(SomeClass).should_receive("instance_method").with_args("red").once()
+        flexmock(SomeClass).should_receive("instance_method").with_args("blue").once()
+        instance = SomeClass()
+        instance.instance_method("red")
+        instance.instance_method("blue")
+        self._tear_down()
+
+        # Class method
+        flexmock(SomeClass).should_receive("class_method").with_args("red").once()
+        flexmock(SomeClass).should_receive("class_method").with_args("blue").once()
+        SomeClass.class_method("red")
+        SomeClass.class_method("blue")
+        self._tear_down()
+
+        # Static method
+        flexmock(SomeClass).should_receive("static_method").with_args("red").once()
+        flexmock(SomeClass).should_receive("static_method").with_args("blue").once()
+        SomeClass.static_method("red")
+        SomeClass.static_method("blue")
 
     def test_flexmock_should_not_blow_up_on_should_call_for_class_methods(self):
         class User:


### PR DESCRIPTION
Closes #48. This is a patch for 0.10.x branch. I'll open another PR to fix this in master. 

When a method was mocked already `expectation.method_type` was not updated and it defaulted to `instancemethod` when it should have been `classmethod`.