### PR TITLE
Fix multiple expectations for the same classmethod are not matched (0.11.x) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,18 @@ all: lint test
 lint: isort black mypy pylint
 
 .PHONY: test
-test: twisted unittest pytest
+test: install twisted unittest pytest
+
+.PHONY: install
+install:
+	@printf '\n\n*****************\n'
+	@printf '$(color)Install flexmock$(off)\n'
+	@printf '*****************\n'
+ifeq (${VIRTUAL_ENV},)
+	@printf 'Skipping install. VIRTUAL_ENV is not set.\n'
+else
+	pip install .
+endif
 
 
 .PHONY: pytest

--- a/src/flexmock/api.py
+++ b/src/flexmock/api.py
@@ -244,19 +244,22 @@ class Mock:
     def _update_method(self, expectation: "Expectation", name: str) -> None:
         method_instance = self._create_mock_method(name)
         obj = self._object
-        if self._hasattr(obj, name) and not hasattr(expectation, "_original"):
-            expectation._update_original(name, obj)
-            method_type = type(_getattr(expectation, "_original"))
-            try:
-                # TODO(herman): this is awful, fix this properly.
-                # When a class/static method is mocked out on an *instance*
-                # we need to fetch the type from the class
-                method_type = type(_getattr(obj.__class__, name))
-            except Exception:
-                pass
-            if method_type in SPECIAL_METHODS:
-                expectation._original_function = getattr(obj, name)
-            expectation._method_type = method_type
+        if self._hasattr(obj, name):
+            if hasattr(expectation, "_original"):
+                expectation._method_type = type(_getattr(expectation, "_original"))
+            else:
+                expectation._update_original(name, obj)
+                method_type = type(_getattr(expectation, "_original"))
+                try:
+                    # TODO(herman): this is awful, fix this properly.
+                    # When a class/static method is mocked out on an *instance*
+                    # we need to fetch the type from the class
+                    method_type = type(_getattr(obj.__class__, name))
+                except Exception:
+                    pass
+                if method_type in SPECIAL_METHODS:
+                    expectation._original_function = getattr(obj, name)
+                expectation._method_type = method_type
         if not inspect.isclass(obj) or expectation._method_type in SPECIAL_METHODS:
             method_instance = types.MethodType(method_instance, obj)
         override = _setattr(obj, name, method_instance)

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -35,12 +35,17 @@ def module_level_function(some, args):
 MODULE_LEVEL_ATTRIBUTE = "test"
 
 
-class OldStyleClass:
-    pass
+class SomeClass:
+    @classmethod
+    def class_method(cls, a):
+        pass
 
+    @staticmethod
+    def static_method(a):
+        pass
 
-class NewStyleClass:
-    pass
+    def instance_method(self, a):
+        pass
 
 
 def assert_raises(exception, method, *kargs, **kwargs):
@@ -1064,21 +1069,13 @@ class RegularClass:
         flexmock(mod).should_receive("module_level_function").with_args(1, args="expected")
         assert_raises(FlexmockError, module_level_function, 1, args="not expected")
 
-    def test_flexmock_should_support_mocking_old_style_classes_as_functions(self):
+    def test_flexmock_should_support_mocking_classes_as_functions(self):
         if "tests.flexmock_test" in sys.modules:
             mod = sys.modules["tests.flexmock_test"]
         else:
             mod = sys.modules["__main__"]
-        flexmock(mod).should_receive("OldStyleClass").and_return("yay")
-        assert_equal("yay", OldStyleClass())
-
-    def test_flexmock_should_support_mocking_new_style_classes_as_functions(self):
-        if "tests.flexmock_test" in sys.modules:
-            mod = sys.modules["tests.flexmock_test"]
-        else:
-            mod = sys.modules["__main__"]
-        flexmock(mod).should_receive("NewStyleClass").and_return("yay")
-        assert_equal("yay", NewStyleClass())
+        flexmock(mod).should_receive("SomeClass").and_return("yay")
+        assert_equal("yay", SomeClass())
 
     def test_flexmock_should_properly_restore_class_methods(self):
         class User:

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -562,6 +562,25 @@ class RegularClass:
         flexmock(User).should_call("bar").once()
         assert_equal("value", user1.bar())
 
+    def test_with_args_with_instance_method(self):
+        flexmock(SomeClass).should_receive("instance_method").with_args("red").once()
+        flexmock(SomeClass).should_receive("instance_method").with_args("blue").once()
+        instance = SomeClass()
+        instance.instance_method("red")
+        instance.instance_method("blue")
+
+    def test_with_args_with_class_method(self):
+        flexmock(SomeClass).should_receive("class_method").with_args("red").once()
+        flexmock(SomeClass).should_receive("class_method").with_args("blue").once()
+        SomeClass.class_method("red")
+        SomeClass.class_method("blue")
+
+    def test_with_args_with_static_method(self):
+        flexmock(SomeClass).should_receive("static_method").with_args("red").once()
+        flexmock(SomeClass).should_receive("static_method").with_args("blue").once()
+        SomeClass.static_method("red")
+        SomeClass.static_method("blue")
+
     def test_flexmock_should_not_blow_up_on_should_call_for_class_methods(self):
         class User:
             @classmethod


### PR DESCRIPTION
Closes #48. See also #54.

When a method was mocked already `expectation.method_type` was not updated and it defaulted to `instancemethod` when it should have been classmethod.

Other changes:
* Update flexmock before running Makefile tests. Running the tests doesn't test against new local changes if flexmock is not re-installed.
* Remove Python 2 class test. This tests didn't do anything anymore.