### PR TITLE
Fix with_args not working with built-in functions and methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,10 @@ Removed
 - Drop Pytest 4.x support.
 - Remove unittest2 and nose integrations. unittest2 and nose are not maintained anymore.
 
+Fixed
+#####
+
+- Fix `with_args` not working built-in functions and methods.
 
 Infrastructure
 ##############

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -1,5 +1,6 @@
 """Flexmock tests."""
 # pylint: disable=missing-docstring,too-many-lines,disallowed-name,no-member,invalid-name,no-self-use
+import random
 import re
 import sys
 import unittest
@@ -312,6 +313,15 @@ class RegularClass:
         assert_equal("got a string", mock.method_foo("string!"))
         assert_equal("got an int", mock.method_foo(23))
         assert_raises(MethodSignatureError, mock.method_foo, 2.0)
+
+    def test_with_args_should_work_with_builtin_c_functions_and_methods(self):
+        flexmock(sys.stdout).should_call("write")  # set fall-through
+        flexmock(sys.stdout).should_receive("write").with_args("flexmock_builtin_test").once()
+        sys.stdout.write("flexmock_builtin_test")
+
+    def test_with_args_should_work_with_builtin_python_methods(self):
+        flexmock(random).should_receive("randint").with_args(1, 10).once()
+        random.randint(1, 10)
 
     def test_flexmock_should_match_expectations_against_user_defined_classes(self):
         mock = flexmock(name="temp")


### PR DESCRIPTION
Fix with_args not working with built-in functions and methods.

## Issue with `sys.stdout.write`
```python
import sys
from flexmock import flexmock

flexmock(sys.stdout).should_receive("write").with_args("test").once()
# Raises: flexmock.exceptions.MethodSignatureError: write requires at least 2 arguments, expectation provided 1
```

Flexmock uses `inspect.ismethod` but it returns `False` for built-in classes written in C. Therefore we need to use `isinstance(self._original, BuiltinMethodType)`. Also determining the method_type doesn't work for built-ins (at least with the current implementation). If a built-in C class can have staticmethods, with_args probably won't work with them. That's something we still need to test.

## Issue with `random.randint`
```python
import random
from flexmock import flexmock

flexmock(random).should_receive("randint").with_args(1, 10).once()
# Raises: flexmock.exceptions.MethodSignatureError: randint requires at least 3 arguments, expectation provided 2
```

`inspect.ismethod` returns `True` for `random.randint` (built-in Python method) but `(not isinstance(self._mock, types.ModuleType)` returns `False` because `random` is a module. Builtin modules seem to have some magic that allows calling class methods without referring to the class.

Closes #37