### PR TITLE
Fix pytest --durations flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixed
 #####
 
 - Fix `with_args` not working built-in functions and methods.
+- Fix pytest ``--durations`` flag when flexmock is installed.
 
 Infrastructure
 ##############

--- a/src/flexmock/integrations.py
+++ b/src/flexmock/integrations.py
@@ -108,7 +108,7 @@ with suppress(ImportError):
         if when != "call" and ret.excinfo is None:
             return ret
         teardown = runner.CallInfo.from_call(flexmock_teardown, when=when)  # type: ignore
-        if hasattr(runner.CallInfo, "duration"):
+        if hasattr(teardown, "duration"):
             # CallInfo.duration only available in Pytest 6+
             teardown.duration = ret.duration
         if ret.excinfo is not None:


### PR DESCRIPTION
The `duration` member variable is an instance variable not a class
variable therefore the hasattr check must be performed on the instance
otherwise it always returns False.

Should have been done in 56c74c97a8f78c723512d5d7a6872f3a4fb9974d.