### PR TITLE
Fix with_args with built-in functions 0.10.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tags
 MANIFEST
 .project
 .ropeproject
+.tox
+_trial_temp

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,13 +10,21 @@ Types of changes:
 - **Infrastructure**: Changes in build or deployment infrastructure.
 - **Documentation**: Changes in documentation.
 
+Release 0.10.8
+--------------
+
+Fixed
+#####
+
+- Fix ``with_args`` not working built-in functions.
+
 Release 0.10.7
 --------------
 
 Fixed
 #####
 
-- Fix ``with_args`` not working built-in functions and methods.
+- Fix ``with_args`` not working built-in methods.
 - Fix previous pytest ``--durations`` fix not working.
 
 Release 0.10.6

--- a/flexmock.py
+++ b/flexmock.py
@@ -248,9 +248,11 @@ class Expectation(object):
         allowed = self.argspec
         args_len = len(allowed.args)
 
+        # self is the first expected argument
+        has_self = allowed.args and allowed.args[0] == "self"
         # Builtin methods take `self` as the first argument but `inspect.ismethod` returns False
         # so we need to check for them explicitly
-        is_builtin_method = isinstance(self.original, types.BuiltinMethodType)
+        is_builtin_method = isinstance(self.original, types.BuiltinMethodType) and has_self
         # Methods take `self` if not a staticmethod
         is_method = inspect.ismethod(self.original) and self.method_type is not staticmethod
         # Class init takes `self`

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -19,6 +19,7 @@ from flexmock import _format_args
 from flexmock import _isproperty
 import flexmock
 import random
+import os
 import re
 import sys
 import unittest
@@ -309,10 +310,19 @@ class RegularClass(object):
         assertEqual('got an int', mock.method_foo(23))
         assertRaises(MethodSignatureError, mock.method_foo, 2.0)
 
-    def test_with_args_should_work_with_builtin_c_functions_and_methods(self):
-        flexmock(sys.stdout).should_call("write")  # set fall-through
-        flexmock(sys.stdout).should_receive("write").with_args("flexmock_builtin_test").once()
-        sys.stdout.write("flexmock_builtin_test")
+    def test_with_args_should_work_with_builtin_c_methods(self):
+        if sys.version_info > (3, 0):
+            flexmock(sys.stdout).should_call("write")  # set fall-through
+            flexmock(sys.stdout).should_receive("write").with_args("flexmock_builtin_test").once()
+            sys.stdout.write("flexmock_builtin_test")
+
+    def test_with_args_should_work_with_builtin_c_functions(self):
+        mocked = flexmock(sys)
+        mocked.should_receive("exit").with_args(1).once()
+        mocked.exit(1)
+        self._tear_down()
+        flexmock(os).should_receive("remove").with_args("path").once()
+        os.remove("path")
 
     def test_with_args_should_work_with_builtin_python_methods(self):
         flexmock(random).should_receive("randint").with_args(1, 10).once()


### PR DESCRIPTION
Closes #73

I disabled `test_with_args_should_work_with_builtin_c_methods` test because it only seems to work with Python 3. Python 2 raises an exception:
```
flexmock.MockBuiltinError: Python does not allow you to mock instances of builtin objects. Consider wrapping it in a class you can mock instead
```
This already happened in version 0.10.4.