### PR TITLE
Fix flexmock not mocking methods properly on derived classes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,14 @@ Types of changes:
 - **Infrastructure**: Changes in build or deployment infrastructure.
 - **Documentation**: Changes in documentation.
 
+Release 0.10.9
+--------------
+
+Fixed
+#####
+
+- Fix flexmock not mocking methods properly on derived classes.
+
 Release 0.10.8
 --------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ copyright = u'2015, Slavek Kabrda, Herman Sheremetyev'
 # built documents.
 #
 # The short X.Y version.
-version = '0.10.8'
+version = '0.10.9'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/flexmock.py
+++ b/flexmock.py
@@ -25,7 +25,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # from flexmock import * is evil, keep it from doing any damage
 __all__ = ['flexmock']
-__version__ = '0.10.8'
+__version__ = '0.10.9'
 
 
 import inspect

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='flexmock',
-      version='0.10.8',
+      version='0.10.9',
       author='Slavek Kabrda, Herman Sheremetyev',
       author_email='slavek@redhat.com',
       url='http://flexmock.readthedocs.org',


### PR DESCRIPTION
Backported changes to 0.10.x branch from #76.
 
Closes #72.