### PR TITLE
Fix AttributeError raised when mocking proxied objects

### DIFF
--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -68,7 +68,7 @@ class SomeClass:
         return a
 
     def instance_method(self):
-        return self.value
+        return self.instance_value
 
     def instance_method_with_args(self, a):
         return a
@@ -751,11 +751,7 @@ class RegularClass:
         flexmock(SomeClassProxy).should_call("static_method").and_return("static_method").twice()
         assert SomeClassProxy().static_method() == "static_method"
         assert SomeClassProxy.static_method() == "static_method"
-
-    @assert_raises(AttributeError, match=None)  # TODO: Should not raise exception
-    def test_spy_proxied_class_instance_method(self):
-        # pylint: disable=not-callable
-        instance = Proxy(SomeClass)()
+        instance = SomeClassProxy()
         flexmock(instance).should_call("instance_method").and_return("instance_method").once()
         assert instance.instance_method() == "instance_method"
 
@@ -784,16 +780,12 @@ class RegularClass:
         flexmock(DerivedClassProxy).should_receive("class_method").and_return(2).twice()
         assert DerivedClassProxy().class_method() == 2
         assert DerivedClassProxy.class_method() == 2
-        instance = DerivedClassProxy()
-        flexmock(instance).should_receive("instance_method").and_return(4).once()
-        assert instance.instance_method() == 4
-
-    def test_mock_proxied_derived_class_static_method(self):
-        # pylint: disable=not-callable
-        DerivedClassProxy = Proxy(DerivedClass)
         flexmock(DerivedClassProxy).should_receive("static_method").and_return(3).twice()
         assert DerivedClassProxy().static_method() == 3
         assert DerivedClassProxy.static_method() == 3
+        instance = DerivedClassProxy()
+        flexmock(instance).should_receive("instance_method").and_return(4).once()
+        assert instance.instance_method() == 4
 
     def test_mock_proxied_module_function(self):
         # pylint: disable=not-callable
@@ -815,20 +807,16 @@ class RegularClass:
         ).and_return(2).twice()
         assert DerivedClassProxy().class_method_with_args("a") == 2
         assert DerivedClassProxy.class_method_with_args("a") == 2
-        instance = DerivedClassProxy()
-        flexmock(instance).should_receive("instance_method_with_args").with_args("c").and_return(
-            4
-        ).once()
-        assert instance.instance_method_with_args("c") == 4
-
-    def test_mock_proxied_derived_class_with_args_static_method(self):
-        # pylint: disable=not-callable
-        DerivedClassProxy = Proxy(DerivedClass)
         flexmock(DerivedClassProxy).should_receive("static_method_with_args").with_args(
             "b"
         ).and_return(3).twice()
         assert DerivedClassProxy().static_method_with_args("b") == 3
         assert DerivedClassProxy.static_method_with_args("b") == 3
+        instance = DerivedClassProxy()
+        flexmock(instance).should_receive("instance_method_with_args").with_args("c").and_return(
+            4
+        ).once()
+        assert instance.instance_method_with_args("c") == 4
 
     def test_spy_proxied_derived_class(self):
         # pylint: disable=not-callable
@@ -836,18 +824,10 @@ class RegularClass:
         flexmock(DerivedClassProxy).should_call("class_method").and_return("class_method").twice()
         assert DerivedClassProxy().class_method() == "class_method"
         assert DerivedClassProxy.class_method() == "class_method"
-
-    def test_spy_proxied_derived_class_static_method(self):
-        # pylint: disable=not-callable
-        DerivedClassProxy = Proxy(DerivedClass)
         flexmock(DerivedClassProxy).should_call("static_method").and_return("static_method").twice()
         assert DerivedClassProxy().static_method() == "static_method"
         assert DerivedClassProxy.static_method() == "static_method"
-
-    @assert_raises(AttributeError, match=None)  # TODO: Should not raise exception
-    def test_spy_proxied_derived_class_instance_method(self):
-        # pylint: disable=not-callable
-        instance = Proxy(DerivedClass)()
+        instance = DerivedClassProxy()
         flexmock(instance).should_call("instance_method").and_return("instance_method").once()
         assert instance.instance_method() == "instance_method"
 
@@ -859,20 +839,16 @@ class RegularClass:
         ).twice()
         assert DerivedClassProxy().class_method_with_args("a") == "a"
         assert DerivedClassProxy.class_method_with_args("a") == "a"
-        instance = DerivedClassProxy()
-        flexmock(instance).should_call("instance_method_with_args").with_args("c").and_return(
-            "c"
-        ).once()
-        assert instance.instance_method_with_args("c") == "c"
-
-    def test_spy_proxied_derived_class_with_args_static_method(self):
-        # pylint: disable=not-callable
-        DerivedClassProxy = Proxy(DerivedClass)
         flexmock(DerivedClassProxy).should_call("static_method_with_args").with_args(
             "b"
         ).and_return("b").twice()
         assert DerivedClassProxy().static_method_with_args("b") == "b"
         assert DerivedClassProxy.static_method_with_args("b") == "b"
+        instance = DerivedClassProxy()
+        flexmock(instance).should_call("instance_method_with_args").with_args("c").and_return(
+            "c"
+        ).once()
+        assert instance.instance_method_with_args("c") == "c"
 
     def test_with_args_with_instance_method(self):
         flexmock(SomeClass).should_receive("instance_method_with_args").with_args("red").once()

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -35,6 +35,8 @@ from flexmock._api import (
 )
 from tests import some_module
 
+from .proxy import Proxy
+
 
 def module_level_function(some, args):
     return "%s, %s" % (some, args)
@@ -44,9 +46,14 @@ MODULE_LEVEL_ATTRIBUTE = "test"
 
 
 class SomeClass:
+    CLASS_VALUE = "class_method"
+
+    def __init__(self):
+        self.instance_value = "instance_method"
+
     @classmethod
     def class_method(cls):
-        return "class_method"
+        return cls.CLASS_VALUE
 
     @classmethod
     def class_method_with_args(cls, a):
@@ -61,7 +68,7 @@ class SomeClass:
         return a
 
     def instance_method(self):
-        return "instance_method"
+        return self.value
 
     def instance_method_with_args(self, a):
         return a
@@ -702,6 +709,170 @@ class RegularClass:
         # Try resetting the expectation
         flexmock(User).should_call("bar").once()
         assert_equal("value", user1.bar())
+
+    def test_mock_proxied_class(self):
+        # pylint: disable=not-callable
+        SomeClassProxy = Proxy(SomeClass)
+        flexmock(SomeClassProxy).should_receive("class_method").and_return(2).twice()
+        assert SomeClassProxy().class_method() == 2
+        assert SomeClassProxy.class_method() == 2
+        flexmock(SomeClassProxy).should_receive("static_method").and_return(3).twice()
+        assert SomeClassProxy().static_method() == 3
+        assert SomeClassProxy.static_method() == 3
+        instance = SomeClassProxy()
+        flexmock(instance).should_receive("instance_method").and_return(4).once()
+        assert instance.instance_method() == 4
+
+    def test_mock_proxied_class_with_args(self):
+        # pylint: disable=not-callable
+        SomeClassProxy = Proxy(SomeClass)
+        flexmock(SomeClassProxy).should_receive("class_method_with_args").with_args("a").and_return(
+            2
+        ).twice()
+        assert SomeClassProxy().class_method_with_args("a") == 2
+        assert SomeClassProxy.class_method_with_args("a") == 2
+        flexmock(SomeClassProxy).should_receive("static_method_with_args").with_args(
+            "b"
+        ).and_return(3).twice()
+        assert SomeClassProxy().static_method_with_args("b") == 3
+        assert SomeClassProxy.static_method_with_args("b") == 3
+        instance = SomeClassProxy()
+        flexmock(instance).should_receive("instance_method_with_args").with_args("c").and_return(
+            4
+        ).once()
+        assert instance.instance_method_with_args("c") == 4
+
+    def test_spy_proxied_class(self):
+        # pylint: disable=not-callable
+        SomeClassProxy = Proxy(SomeClass)
+        flexmock(SomeClassProxy).should_call("class_method").and_return("class_method").twice()
+        assert SomeClassProxy().class_method() == "class_method"
+        assert SomeClassProxy.class_method() == "class_method"
+        flexmock(SomeClassProxy).should_call("static_method").and_return("static_method").twice()
+        assert SomeClassProxy().static_method() == "static_method"
+        assert SomeClassProxy.static_method() == "static_method"
+
+    @assert_raises(AttributeError, match=None)  # TODO: Should not raise exception
+    def test_spy_proxied_class_instance_method(self):
+        # pylint: disable=not-callable
+        instance = Proxy(SomeClass)()
+        flexmock(instance).should_call("instance_method").and_return("instance_method").once()
+        assert instance.instance_method() == "instance_method"
+
+    def test_spy_proxied_class_with_args(self):
+        # pylint: disable=not-callable
+        SomeClassProxy = Proxy(SomeClass)
+        flexmock(SomeClassProxy).should_call("class_method_with_args").with_args("a").and_return(
+            "a"
+        ).twice()
+        assert SomeClassProxy().class_method_with_args("a") == "a"
+        assert SomeClassProxy.class_method_with_args("a") == "a"
+        flexmock(SomeClassProxy).should_call("static_method_with_args").with_args("b").and_return(
+            "b"
+        ).twice()
+        assert SomeClassProxy().static_method_with_args("b") == "b"
+        assert SomeClassProxy.static_method_with_args("b") == "b"
+        instance = SomeClassProxy()
+        flexmock(instance).should_call("instance_method_with_args").with_args("c").and_return(
+            "c"
+        ).once()
+        assert instance.instance_method_with_args("c") == "c"
+
+    def test_mock_proxied_derived_class(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_receive("class_method").and_return(2).twice()
+        assert DerivedClassProxy().class_method() == 2
+        assert DerivedClassProxy.class_method() == 2
+        instance = DerivedClassProxy()
+        flexmock(instance).should_receive("instance_method").and_return(4).once()
+        assert instance.instance_method() == 4
+
+    def test_mock_proxied_derived_class_static_method(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_receive("static_method").and_return(3).twice()
+        assert DerivedClassProxy().static_method() == 3
+        assert DerivedClassProxy.static_method() == 3
+
+    def test_mock_proxied_module_function(self):
+        # pylint: disable=not-callable
+        some_module_proxy = Proxy(some_module)
+        flexmock(some_module_proxy).should_receive("module_function").and_return(3).once()
+        assert some_module_proxy.module_function() == 3
+
+    def test_spy_proxied_module_function(self):
+        # pylint: disable=not-callable
+        some_module_proxy = Proxy(some_module)
+        flexmock(some_module_proxy).should_receive("module_function").and_return(0).once()
+        assert some_module_proxy.module_function(2, 2) == 0
+
+    def test_mock_proxied_derived_class_with_args(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_receive("class_method_with_args").with_args(
+            "a"
+        ).and_return(2).twice()
+        assert DerivedClassProxy().class_method_with_args("a") == 2
+        assert DerivedClassProxy.class_method_with_args("a") == 2
+        instance = DerivedClassProxy()
+        flexmock(instance).should_receive("instance_method_with_args").with_args("c").and_return(
+            4
+        ).once()
+        assert instance.instance_method_with_args("c") == 4
+
+    def test_mock_proxied_derived_class_with_args_static_method(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_receive("static_method_with_args").with_args(
+            "b"
+        ).and_return(3).twice()
+        assert DerivedClassProxy().static_method_with_args("b") == 3
+        assert DerivedClassProxy.static_method_with_args("b") == 3
+
+    def test_spy_proxied_derived_class(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_call("class_method").and_return("class_method").twice()
+        assert DerivedClassProxy().class_method() == "class_method"
+        assert DerivedClassProxy.class_method() == "class_method"
+
+    def test_spy_proxied_derived_class_static_method(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_call("static_method").and_return("static_method").twice()
+        assert DerivedClassProxy().static_method() == "static_method"
+        assert DerivedClassProxy.static_method() == "static_method"
+
+    @assert_raises(AttributeError, match=None)  # TODO: Should not raise exception
+    def test_spy_proxied_derived_class_instance_method(self):
+        # pylint: disable=not-callable
+        instance = Proxy(DerivedClass)()
+        flexmock(instance).should_call("instance_method").and_return("instance_method").once()
+        assert instance.instance_method() == "instance_method"
+
+    def test_spy_proxied_derived_class_with_args(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_call("class_method_with_args").with_args("a").and_return(
+            "a"
+        ).twice()
+        assert DerivedClassProxy().class_method_with_args("a") == "a"
+        assert DerivedClassProxy.class_method_with_args("a") == "a"
+        instance = DerivedClassProxy()
+        flexmock(instance).should_call("instance_method_with_args").with_args("c").and_return(
+            "c"
+        ).once()
+        assert instance.instance_method_with_args("c") == "c"
+
+    def test_spy_proxied_derived_class_with_args_static_method(self):
+        # pylint: disable=not-callable
+        DerivedClassProxy = Proxy(DerivedClass)
+        flexmock(DerivedClassProxy).should_call("static_method_with_args").with_args(
+            "b"
+        ).and_return("b").twice()
+        assert DerivedClassProxy().static_method_with_args("b") == "b"
+        assert DerivedClassProxy.static_method_with_args("b") == "b"
 
     def test_with_args_with_instance_method(self):
         flexmock(SomeClass).should_receive("instance_method_with_args").with_args("red").once()
@@ -2707,6 +2878,28 @@ class RegularClass:
         assert _is_class_method(derived_class.static_method, "static_method") is False
         assert _is_class_method(derived_class.instance_method, "instance_method") is False
 
+    def test_is_class_method_proxied(self):
+        # pylint: disable=not-callable
+        SomeClassProxy = Proxy(SomeClass)
+        assert _is_class_method(SomeClassProxy.class_method, "class_method") is True
+        assert _is_class_method(SomeClassProxy.static_method, "static_method") is False
+        assert _is_class_method(SomeClassProxy.instance_method, "instance_method") is False
+
+        some_class = SomeClassProxy()
+        assert _is_class_method(some_class.class_method, "class_method") is True
+        assert _is_class_method(some_class.static_method, "static_method") is False
+        assert _is_class_method(some_class.instance_method, "instance_method") is False
+
+        DerivedClassProxy = Proxy(DerivedClass)
+        assert _is_class_method(DerivedClassProxy.class_method, "class_method") is True
+        assert _is_class_method(DerivedClassProxy.static_method, "static_method") is False
+        assert _is_class_method(DerivedClassProxy.instance_method, "instance_method") is False
+
+        derived_class = DerivedClassProxy()
+        assert _is_class_method(derived_class.class_method, "class_method") is True
+        assert _is_class_method(derived_class.static_method, "static_method") is False
+        assert _is_class_method(derived_class.instance_method, "instance_method") is False
+
     def test_is_static_method(self):
         assert _is_static_method(SomeClass, "class_method") is False
         assert _is_static_method(SomeClass, "static_method") is True
@@ -2722,6 +2915,28 @@ class RegularClass:
         assert _is_static_method(DerivedClass, "instance_method") is False
 
         derived_class = DerivedClass()
+        assert _is_static_method(derived_class, "class_method") is False
+        assert _is_static_method(derived_class, "static_method") is True
+        assert _is_static_method(derived_class, "instance_method") is False
+
+    def test_is_static_method_proxied(self):
+        # pylint: disable=not-callable
+        SomeClassProxy = Proxy(SomeClass)
+        assert _is_static_method(SomeClassProxy, "class_method") is False
+        assert _is_static_method(SomeClassProxy, "static_method") is True
+        assert _is_static_method(SomeClassProxy, "instance_method") is False
+
+        some_class = SomeClassProxy()
+        assert _is_static_method(some_class, "class_method") is False
+        assert _is_static_method(some_class, "static_method") is True
+        assert _is_static_method(some_class, "instance_method") is False
+
+        DerivedClassProxy = Proxy(DerivedClass)
+        assert _is_static_method(DerivedClassProxy, "class_method") is False
+        assert _is_static_method(DerivedClassProxy, "static_method") is True
+        assert _is_static_method(DerivedClassProxy, "instance_method") is False
+
+        derived_class = DerivedClassProxy()
         assert _is_static_method(derived_class, "class_method") is False
         assert _is_static_method(derived_class, "static_method") is True
         assert _is_static_method(derived_class, "instance_method") is False

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -1,0 +1,144 @@
+"""Proxy class for testing proxied objects."""
+
+
+class Proxy:
+    """Proxy to another object."""
+
+    # OBJECT PROXYING (PYTHON RECIPE)
+    # https://code.activestate.com/recipes/496741-object-proxying/
+
+    def __init__(self, obj):
+        object.__setattr__(self, "_obj", obj)
+
+    def __getattribute__(self, name):
+        return getattr(object.__getattribute__(self, "_obj"), name)
+
+    def __delattr__(self, name):
+        delattr(object.__getattribute__(self, "_obj"), name)
+
+    def __setattr__(self, name, value):
+        setattr(object.__getattribute__(self, "_obj"), name, value)
+
+    def __nonzero__(self):
+        return bool(object.__getattribute__(self, "_obj"))
+
+    def __str__(self):
+        return str(object.__getattribute__(self, "_obj"))
+
+    def __repr__(self):
+        return repr(object.__getattribute__(self, "_obj"))
+
+    _special_names = [
+        "__abs__",
+        "__add__",
+        "__and__",
+        "__call__",
+        "__cmp__",
+        "__coerce__",
+        "__contains__",
+        "__delitem__",
+        "__delslice__",
+        "__div__",
+        "__divmod__",
+        "__eq__",
+        "__float__",
+        "__floordiv__",
+        "__ge__",
+        "__getitem__",
+        "__getslice__",
+        "__gt__",
+        "__hash__",
+        "__hex__",
+        "__iadd__",
+        "__iand__",
+        "__idiv__",
+        "__idivmod__",
+        "__ifloordiv__",
+        "__ilshift__",
+        "__imod__",
+        "__imul__",
+        "__int__",
+        "__invert__",
+        "__ior__",
+        "__ipow__",
+        "__irshift__",
+        "__isub__",
+        "__iter__",
+        "__itruediv__",
+        "__ixor__",
+        "__le__",
+        "__len__",
+        "__long__",
+        "__lshift__",
+        "__lt__",
+        "__mod__",
+        "__mul__",
+        "__ne__",
+        "__neg__",
+        "__oct__",
+        "__or__",
+        "__pos__",
+        "__pow__",
+        "__radd__",
+        "__rand__",
+        "__rdiv__",
+        "__rdivmod__",
+        "__reduce__",
+        "__reduce_ex__",
+        "__repr__",
+        "__reversed__",
+        "__rfloorfiv__",
+        "__rlshift__",
+        "__rmod__",
+        "__rmul__",
+        "__ror__",
+        "__rpow__",
+        "__rrshift__",
+        "__rshift__",
+        "__rsub__",
+        "__rtruediv__",
+        "__rxor__",
+        "__setitem__",
+        "__setslice__",
+        "__sub__",
+        "__truediv__",
+        "__xor__",
+        "next",
+    ]
+
+    @classmethod
+    def _create_class_proxy(cls, theclass):
+        """Creates a proxy for the given class."""
+
+        def make_method(name):
+            def method(self, *args, **kw):
+                return getattr(object.__getattribute__(self, "_obj"), name)(*args, **kw)
+
+            return method
+
+        namespace = {}
+        for name in cls._special_names:
+            if hasattr(theclass, name):
+                namespace[name] = make_method(name)
+        return type(f"{cls.__name__}({theclass.__name__})", (cls,), namespace)
+
+    def __new__(cls, obj, *args, **kwargs):
+        """Creates an proxy instance referencing `obj`.
+
+        (obj, *args, **kwargs) are passed to this class' __init__, so deriving
+        classes can define an __init__ method of their own.
+
+        note: _class_proxy_cache is unique per deriving class (each deriving
+        class must hold its own cache)
+        """
+        try:
+            cache = cls.__dict__["_class_proxy_cache"]
+        except KeyError:
+            cls._class_proxy_cache = cache = {}
+        try:
+            theclass = cache[obj.__class__]
+        except KeyError:
+            cache[obj.__class__] = theclass = cls._create_class_proxy(obj.__class__)
+        ins = object.__new__(theclass)
+        theclass.__init__(ins, obj, *args, **kwargs)
+        return ins


### PR DESCRIPTION
Closes #81 

**TODO**:
- [x] Fix or create an issue: Spying instance method on a proxy object passes wrong `runtime_self`