### PR TITLE
Change `once`, `twice`, and `never` properties to methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,8 @@ Added
 Changed
 #######
 
-- Flexmock needs to be imported explicitly using ``from flexmock import flexmock``.
+- **BREAKING CHANGE**: Flexmock needs to be imported explicitly using `from flexmock import flexmock`.
+  The hack that allowed flexmock to be imported directly using `import flexmock` did not work well with static analysis tools.
 - Many error messages have been improved.
 - Undocumented methods `Expectation.reset`, `Expectation.verify`, and `Expectation.match_args` that were unintentionally left public are now private methods.
 
@@ -33,12 +34,14 @@ Removed
 - Drop Python 2.7, 3.4, 3.5 support.
 - Drop Pytest 4.x support.
 - Remove unittest2 and nose integrations. unittest2 and nose are not maintained anymore.
+- **BREAKING CHANGE**: Removed support for calling `once`, `twice`, `never`, and `mock` methods
+  without parentheses. This allows code completion and static analysis to work with these methods.
 
 Fixed
 #####
 
-- Fix `with_args` not working built-in functions and methods.
 - Fix `should_call` is broken if called on a fake object.
+- Fix `and_raise` allows invalid arguments for an exception.
 
 Infrastructure
 ##############

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,4 +9,4 @@ flexmock API
   :members: should_receive, should_call, new_instances
 
 .. autoclass:: Expectation
-  :members: with_args, and_return, and_raise, replace_with, and_yield, when, times, at_least, at_most, ordered, one_by_one, mock
+  :members: with_args, and_return, and_raise, replace_with, and_yield, when, times, once, twice, never, at_least, at_most, ordered, one_by_one, mock

--- a/tests/flexmock_pytest_test.py
+++ b/tests/flexmock_pytest_test.py
@@ -19,7 +19,7 @@ def test_module_level_test_for_pytest():
 
 @pytest.fixture()
 def runtest_hook_fixture():
-    return flexmock(foo="bar").should_receive("foo").once.mock()
+    return flexmock(foo="bar").should_receive("foo").once().mock()
 
 
 def test_runtest_hook_with_fixture_for_pytest(runtest_hook_fixture):

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -148,6 +148,22 @@ class RegularClass:
         assert_equal("value_bar", mock.method_foo())
         assert_equal("value_baz", mock.method_bar())
 
+    def test_calling_deprecated_properties_should_raise_exception(self):
+        error_msg = "Calling once, twice, never, or mock without parentheses has been deprecated"
+        mock = flexmock()
+        mock.should_receive("foo").once  # pylint: disable=expression-not-assigned
+        with assert_raises(FlexmockError, error_msg):
+            self._tear_down()
+        mock.should_receive("foo").twice  # pylint: disable=expression-not-assigned
+        with assert_raises(FlexmockError, error_msg):
+            self._tear_down()
+        mock.should_receive("foo").never  # pylint: disable=expression-not-assigned
+        with assert_raises(FlexmockError, error_msg):
+            self._tear_down()
+        mock.should_receive("foo").mock  # pylint: disable=expression-not-assigned
+        with assert_raises(FlexmockError, error_msg):
+            self._tear_down()
+
     def test_type_flexmock_with_unicode_string_in_should_receive(self):
         class Foo:
             def bar(self):
@@ -320,7 +336,7 @@ class RegularClass:
 
     def test_expectation_dot_mock_should_return_mock(self):
         mock = flexmock(name="temp")
-        assert_equal(mock, mock.should_receive("method_foo").mock)
+        assert_equal(mock, mock.should_receive("method_foo").mock())
 
     def test_flexmock_should_create_partial_new_style_object_mock(self):
         class User:
@@ -661,8 +677,8 @@ class RegularClass:
 
         user = User()
         user2 = User()
-        class_mock = flexmock(User).should_receive("method").and_return("class").mock
-        user_mock = flexmock(user).should_receive("method").and_return("instance").mock
+        class_mock = flexmock(User).should_receive("method").and_return("class").mock()
+        user_mock = flexmock(user).should_receive("method").and_return("instance").mock()
         assert class_mock is not user_mock
         assert_equal("instance", user.method())
         assert_equal("class", user2.method())
@@ -1750,6 +1766,12 @@ class RegularClass:
         with assert_raises(RuntimeError, "bar"):
             RaisesException.static_method()
 
+    def test_and_raise_with_invalid_arguments(self):
+        with assert_raises(
+            FlexmockError, "can't initialize <class 'Exception'> with the given arguments"
+        ):
+            flexmock().should_receive("foo").and_raise(Exception, 1, bar=2)
+
     def test_and_raise_with_value_that_is_not_a_class(self):
         class RaisesException:
             def get_stuff(self):
@@ -1972,7 +1994,7 @@ class RegularClass:
         class User:
             pass
 
-        mock = flexmock(User).new_instances(None).mock
+        mock = flexmock(User).new_instances(None).mock()
         with assert_raises(FlexmockError, "User does not have attribute 'foo'"):
             mock.should_receive("foo")
 
@@ -2979,7 +3001,7 @@ class ModernClass:
     def test_builtin_open(self):
         mock = flexmock(sys.modules["builtins"])
         fake_fd = flexmock(read=lambda: "some data")
-        mock.should_receive("open").once.with_args("file_name").and_return(fake_fd)
+        mock.should_receive("open").once().with_args("file_name").and_return(fake_fd)
         with open("file_name") as f:  # pylint: disable=unspecified-encoding
             data = f.read()
         self.assertEqual("some data", data)


### PR DESCRIPTION
Changed `once`, `twice`, `never` and `mock` properties to methods. This allows code completion to work for these methods. Previously it was possible to call these methods without parentheses as if they were properties.

To avoid silently breaking user code (eg. `mock.once` would get ignored), an exception is raised if one of these methods is called without parentheses.