### PR TITLE
Update code examples

### DIFF
--- a/docs/compare.rst
+++ b/docs/compare.rst
@@ -1,11 +1,11 @@
 Mock Library Comparison
 =======================
 
-(flexmock for Mox or Mock users.)
+(flexmock for Mock users.)
 ---------------------------------------------------------------
 
 This document shows a side-by-side comparison of how to accomplish some
-basic tasks with flexmock as well as other popular Python mocking libraries.
+basic tasks with flexmock compared to Python unittest Mock.
 
 Simple fake object (attributes only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -13,23 +13,16 @@ Simple fake object (attributes only)
 ::
 
     # flexmock
-    mock = flexmock(some_attribute="value", some_other_attribute="value2")
-    assertEquals("value", mock.some_attribute)
-    assertEquals("value2", mock.some_other_attribute)
-
-    # Mox
-    mock = mox.MockAnything()
-    mock.some_attribute = "value"
-    mock.some_other_attribute = "value2"
-    assertEquals("value", mock.some_attribute)
-    assertEquals("value2", mock.some_other_attribute)
+    my_mock = flexmock(some_attribute="value", some_other_attribute="value2")
+    assert my_mock.some_attribute == "value"
+    assert my_mock.some_other_attribute == "value2"
 
     # Mock
     my_mock = mock.Mock()
     my_mock.some_attribute = "value"
     my_mock.some_other_attribute = "value2"
-    assertEquals("value", my_mock.some_attribute)
-    assertEquals("value2", my_mock.some_other_attribute)
+    assert my_mock.some_attribute == "value"
+    assert my_mock.some_other_attribute == "value2"
 
 
 Simple fake object (with methods)
@@ -38,19 +31,13 @@ Simple fake object (with methods)
 ::
 
     # flexmock
-    mock = flexmock(some_method=lambda: "calculated value")
-    assertEquals("calculated value", mock.some_method())
-
-    # Mox
-    mock = mox.MockAnything()
-    mock.some_method().AndReturn("calculated value")
-    mox.Replay(mock)
-    assertEquals("calculated value", mock.some_method())
+    my_mock = flexmock(some_method=lambda: "calculated value")
+    assert my_mock.some_method() == "calculated value"
 
     # Mock
     my_mock = mock.Mock()
     my_mock.some_method.return_value = "calculated value"
-    assertEquals("calculated value", my_mock.some_method())
+    assert my_mock.some_method() == "calculated value"
 
 
 Simple mock
@@ -59,21 +46,14 @@ Simple mock
 ::
 
     # flexmock
-    mock = flexmock()
-    mock.should_receive("some_method").and_return("value").once()
-    assertEquals("value", mock.some_method())
-
-    # Mox
-    mock = mox.MockAnything()
-    mock.some_method().AndReturn("value")
-    mox.Replay(mock)
-    assertEquals("value", mock.some_method())
-    mox.Verify(mock)
+    my_mock = flexmock()
+    my_mock.should_receive("some_method").and_return("value").once()
+    assert my_mock.some_method() == "value"
 
     # Mock
     my_mock = mock.Mock()
     my_mock.some_method.return_value = "value"
-    assertEquals("value", mock.some_method())
+    assert my_mock.some_method() == "value"
     my_mock.some_method.assert_called_once_with()
 
 
@@ -83,20 +63,13 @@ Creating partial mocks
 ::
 
     # flexmock
-    flexmock(SomeObject).should_receive("some_method").and_return('value')
-    assertEquals("value", mock.some_method())
-
-    # Mox
-    mock = mox.MockObject(SomeObject)
-    mock.some_method().AndReturn("value")
-    mox.Replay(mock)
-    assertEquals("value", mock.some_method())
-    mox.Verify(mock)
+    flexmock(SomeClass).should_receive("some_method").and_return("value")
+    assert SomeClass.some_method() == "value"
 
     # Mock
-    with mock.patch("SomeObject") as my_mock:
-      my_mock.some_method.return_value = "value"
-      assertEquals("value", mock.some_method())
+    with mock.patch("SomeClass") as my_mock:
+        my_mock.some_method.return_value = "value"
+        assert SomeClass.some_method() == "value"
 
 
 Ensure calls are made in specific order
@@ -105,25 +78,18 @@ Ensure calls are made in specific order
 ::
 
     # flexmock
-    mock = flexmock(SomeObject)
-    mock.should_receive('method1').once().ordered().and_return('first thing')
-    mock.should_receive('method2').once().ordered().and_return('second thing')
-    # exercise the code
-
-    # Mox
-    mock = mox.MockObject(SomeObject)
-    mock.method1().AndReturn('first thing')
-    mock.method2().AndReturn('second thing')
-    mox.Replay(mock)
-    # exercise the code
-    mox.Verify(mock)
+    # flexmock
+    my_mock = flexmock(SomeClass)
+    my_mock.should_receive("method1").ordered().and_return("first thing").once()
+    my_mock.should_receive("method2").ordered().and_return("second thing").once()
+    # execute the code
 
     # Mock
-    mock = mock.Mock(spec=SomeObject)
-    mock.method1.return_value = 'first thing'
-    mock.method2.return_value = 'second thing'
-    # exercise the code
-    assert mock.method_calls == [('method1',) ('method2',)]
+    my_mock = mock.Mock(spec=SomeClass)
+    my_mock.method1.return_value = "first thing"
+    my_mock.method2.return_value = "second thing"
+    # execute the code
+    assert my_mock.method_calls == [("method1",), ("method2",)]
 
 
 Raising exceptions
@@ -132,16 +98,9 @@ Raising exceptions
 ::
 
     # flexmock
-    mock = flexmock()
-    mock.should_receive("some_method").and_raise(SomeException("message"))
-    assertRaises(SomeException, mock.some_method)
-
-    # Mox
-    mock = mox.MockAnything()
-    mock.some_method().AndRaise(SomeException("message"))
-    mox.Replay(mock)
-    assertRaises(SomeException, mock.some_method)
-    mox.Verify(mock)
+    my_mock = flexmock()
+    my_mock.should_receive("some_method").and_raise(SomeException, "message")
+    assertRaises(SomeException, my_mock.some_method)
 
     # Mock
     my_mock = mock.Mock()
@@ -156,19 +115,12 @@ Override new instances of a class
 
     # flexmock
     flexmock(some_module.SomeClass).new_instances(some_other_object)
-    assertEqual(some_other_object, some_module.SomeClass())
-
-    # Mox
-    # (you will probably have mox.Mox() available as self.mox in a real test)
-    mox.Mox().StubOutWithMock(some_module, 'SomeClass', use_mock_anything=True)
-    some_module.SomeClass().AndReturn(some_other_object)
-    mox.ReplayAll()
-    assertEqual(some_other_object, some_module.SomeClass())
+    assert some_other_object == some_module.SomeClass()
 
     # Mock
-    with mock.patch('somemodule.Someclass') as MockClass:
-      MockClass.return_value = some_other_object
-      assert some_other_object == some_module.SomeClass()
+    with mock.patch("somemodule.Someclass") as MockClass:
+        MockClass.return_value = some_other_object
+        assert some_other_object == some_module.SomeClass()
 
 
 Verify a method was called multiple times
@@ -177,21 +129,12 @@ Verify a method was called multiple times
 ::
 
     # flexmock (verifies that the method gets called at least twice)
-    flexmock(some_object).should_receive('some_method').at_least().twice()
-    # exercise the code
-    
-    # Mox
-    # (does not support variable number of calls, so you need to create a new entry for each explicit call)
-    mock = mox.MockObject(some_object)
-    mock.some_method(mox.IgnoreArg(), mox.IgnoreArg())
-    mock.some_method(mox.IgnoreArg(), mox.IgnoreArg())
-    mox.Replay(mock)
-    # exercise the code
-    mox.Verify(mock)
-    
+    flexmock(some_object).should_receive("some_method").at_least().twice()
+    # execute the code
+
     # Mock
-    my_mock = mock.Mock(spec=SomeObject)
-    # exercise the code
+    my_mock = mock.Mock(spec=SomeClass)
+    # execute the code
     assert my_mock.some_method.call_count >= 2
 
 
@@ -203,30 +146,17 @@ Mock chained methods
     # flexmock
     # (intermediate method calls are automatically assigned to temporary fake objects
     # and can be called with any arguments)
-    (flexmock(some_object)
-        .should_receive('method1.method2.method3')
-        .with_args(arg1, arg2)
-        .and_return('some value'))
-    assertEqual('some_value', some_object.method1().method2().method3(arg1, arg2))
-
-    # Mox
-    mock = mox.MockObject(some_object)
-    mock2 = mox.MockAnything()
-    mock3 = mox.MockAnything()
-    mock.method1().AndReturn(mock1)
-    mock2.method2().AndReturn(mock2)
-    mock3.method3(arg1, arg2).AndReturn('some_value')
-    self.mox.ReplayAll()
-    assertEqual("some_value", some_object.method1().method2().method3(arg1, arg2))
-    self.mox.VerifyAll()
+    flexmock(some_object).should_receive("method1.method2.method3").with_args(
+        arg1, arg2
+    ).and_return("some value")
+    assert some_object.method1().method2().method3(arg1, arg2) == "some_value"
 
     # Mock
     my_mock = mock.Mock()
-    my_mock.method1.return_value.method2.return_value.method3.return_value = 'some value'
+    my_mock.method1.return_value.method2.return_value.method3.return_value = "some value"
     method3 = my_mock.method1.return_value.method2.return_value.method3
     method3.assert_called_once_with(arg1, arg2)
-    assertEqual('some_value', my_mock.method1().method2().method3(arg1, arg2))
-
+    assert my_mock.method1().method2().method3(arg1, arg2) == "some_value"
 
 Mock context manager
 ~~~~~~~~~~~~~~~~~~~~
@@ -243,54 +173,28 @@ Mock context manager
     with my_mock:
         pass
 
-    # Mox
-    my_mock = mox.MockAnything()
-    with my_mock:
-        pass
-
 
 Mocking the builtin open used as a context manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following examples work in an interactive Python session but may not work
-quite the same way in a script, or with Python 3.0+. See examples in the
-:ref:`builtin_functions` section for more specific flexmock instructions
-on mocking builtins.
+quite the same way in a script. See examples in the :ref:`builtin_functions`
+section for more specific flexmock instructions on mocking builtins.
 
 ::
 
     # flexmock
-    (flexmock(__builtins__)
-        .should_receive('open')
-        .once()
-        .with_args('file_name')
-        .and_return(flexmock(read=lambda: 'some data')))
-    with open('file_name') as f:
-        assertEqual('some data', f.read())                    
-
-    # Mox
-    self_mox = mox.Mox()
-    mock_file = mox.MockAnything()
-    mock_file.read().AndReturn('some data')
-    self_mox.StubOutWithMock(__builtins__, 'open')           
-    __builtins__.open('file_name').AndReturn(mock_file)            
-    self_mox.ReplayAll()
-    with mock_file:
-        assertEqual('some data', mock_file.read())
-    self_mox.VerifyAll()
+    flexmock(__builtins__).should_receive("open").with_args("file_name").and_return(
+        flexmock(read=lambda: "some data")
+    ).once()
+    with open("file_name") as file:
+        assert file.read() == "some data"
 
     # Mock
-    with mock.patch('__builtin__.open') as my_mock:
+    with mock.patch("builtins.open") as my_mock:
         my_mock.return_value.__enter__ = lambda s: s
         my_mock.return_value.__exit__ = mock.Mock()
-        my_mock.return_value.read.return_value = 'some data'
-        with open('file_name') as h:
-            assertEqual('some data', h.read())
-    my_mock.assert_called_once_with('foo')
-
-
-A possibly more up-to-date version of this document, featuring more mocking
-libraries, is availale at:
-
-http://garybernhardt.github.com/python-mock-comparison/
-
+        my_mock.return_value.read.return_value = "some data"
+        with open("file_name") as file:
+            assert file.read() == "some data"
+    my_mock.assert_called_once_with("file_name")

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -15,12 +15,14 @@ For example, to create a FakePlane object to use in a test in place of a real Pl
 
 ::
 
-  class FakePlane(object):
-      operational = True
-      model = "MIG-21"
-      def fly(self): pass
+    class FakePlane:
+        operational = True
+        model = "MIG-21"
 
-  plane = FakePlane()  # this is tedious!
+        def fly(self):
+            pass
+
+    plane = FakePlane()  # this is tedious!
 
 In other words, we must first create a class, make sure it contains all required attributes and methods, and finally instantiate it to create the object.
 
@@ -29,17 +31,14 @@ function:
 
 ::
 
-  plane = flexmock(operational=True,
-                   model="MIG-21")
+    plane = flexmock(operational=True, model="MIG-21")
 
 
 It is also possible to add methods to this object using the same notation and Python's handy lambda keyword to turn an attribute into a method:
 
 ::
 
-  plane = flexmock(operational=True,
-                   model="MIG-21",
-                   fly=lambda: None)
+    plane = flexmock(operational=True, model="MIG-21", fly=lambda: None)
 
 
 Replacing parts of existing objects and classes (stubs)
@@ -52,9 +51,9 @@ fake ones. flexmock makes this easy as well:
 
 ::
 
-  flexmock(Train,  # this can be an instance, a class, or a module
-           get_destination="Tokyo",
-           get_speed=200)
+    flexmock(Train,  # this can be an instance, a class, or a module
+             get_destination="Tokyo",
+             get_speed=200)
 
 
 By passing a real object (or class or module) into the flexmock() function as the first argument
@@ -66,10 +65,8 @@ an entirely different method and substitute return values based on test-specific
 
 ::
 
-  (flexmock(Train)
-      .should_receive("get_route")
-      .replace_with(lambda x: custom_get_route()))
-      
+    flexmock(Train).should_receive("get_route").replace_with(lambda x: custom_get_route())
+
 
 Creating and checking expectations
 ----------------------------------
@@ -88,7 +85,7 @@ The first and simplest is ensuring that a certain method is called:
 
 ::
 
-  flexmock(Train).should_receive("get_destination").once()
+    flexmock(Train).should_receive("get_destination").once()
 
 
 The .once() modifier ensures that Train.get_destination() is called at some point during the test and
@@ -98,14 +95,14 @@ Of course, it is also possible to provide a default return value:
 
 ::
 
-  flexmock(Train).should_receive("get_destination").once().and_return("Tokyo")
+    flexmock(Train).should_receive("get_destination").and_return("Tokyo").once()
 
 
 Or check that a method is called with specific arguments:
 
 ::
 
-  flexmock(Train).should_receive("set_destination").with_args("Tokyo").at_least().times(1)
+    flexmock(Train).should_receive("set_destination").with_args("Tokyo").at_least().times(1)
 
 
 In this example we used .times(1) instead of .once() and added the .at_least() modifier
@@ -124,7 +121,7 @@ sort of expectations instead of should_receive():
 
 ::
 
-  flexmock(Train).should_call("get_destination").once()
+    flexmock(Train).should_call("get_destination").once()
 
 
 In the above case the real get_destination() method will be executed, but flexmock will raise
@@ -134,11 +131,9 @@ values and call times.
 
 ::
 
-  (flexmock(Train)
-      .should_call("set_destination")
-      .once()
-      .with_args(object, str, int)
-      .and_raise(Exception, re.compile("^No such dest.*")))
+    flexmock(Train).should_call("set_destination").with_args(object, str, int).and_raise(
+        Exception, re.compile("^No such dest.*")
+    ).once()
 
 
 The above example introduces a handful of new capabilities -- raising exceptions, matching argument types (object naturally matches any argument type) and regex matching on string return values and arguments.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -117,34 +117,34 @@ Mark the object as partially mocked, allowing it to be used to create new expect
 ::
 
     flexmock(plane)
-    plane.should_receive('fly').and_return('vooosh!').once()
-    plane.should_receive('land').and_return('landed!').once()
+    plane.should_receive("fly").and_return("vooosh!").once()
+    plane.should_receive("land").and_return("landed!").once()
 
 Equivalent syntax assigns the partially mocked object to a variable
 
 ::
 
     plane = flexmock(plane)
-    plane.should_receive('fly').and_return('vooosh!').once()
-    plane.should_receive('land').and_return('landed!').once()
+    plane.should_receive("fly").and_return("vooosh!").once()
+    plane.should_receive("land").and_return("landed!").once()
 
 Or you can combine everything into one line if there is only one method to override
 
 ::
 
-    flexmock(plane).should_receive('fly').and_return('vooosh!').once()
+    flexmock(plane).should_receive("fly").and_return("vooosh!").once()
 
 You can also return the mock object after setting the expectations
 
 ::
 
-    plane = flexmock(plane).should_receive('fly').and_return('vooosh!').mock()
+    plane = flexmock(plane).should_receive("fly").and_return("vooosh!").mock()
 
 Note the "mock" modifier above -- the expectation chain returns an expectation otherwise
 
 ::
 
-    plane.should_receive('land').with_args().and_return('foo', 'bar')
+    plane.should_receive("land").with_args().and_return("foo", "bar")
 
 
 :NOTE: If you do not provide a with_args() modifier then any set of arguments, including none, will be matched.  However, if you specify with_args() the expectation will only match exactly zero arguments.
@@ -168,7 +168,7 @@ in the same call:
 
 ::
 
-    flexmock(plane, fly='voooosh!', land=('foo', 'bar'))
+    flexmock(plane, fly="voooosh!", land=("foo", "bar"))
 
 This approach is handy and quick but only limited to stubs, i.e.
 it is not possible to further modify these kind of calls with any of
@@ -184,13 +184,13 @@ method for all instances of that class.
 
     >>> class User:
     >>>     def get_name(self):
-    >>>         return 'George Bush'
+    >>>         return "George Bush"
     >>>
     >>> flexmock(User)
-    >>> User.should_receive('get_name').and_return('Bill Clinton')
+    >>> User.should_receive("get_name").and_return("Bill Clinton")
     >>> bubba = User()
     >>> bubba.get_name()
-    'Bill Clinton'
+    "Bill Clinton"
 
 Automatically checked expectations
 ----------------------------------
@@ -199,41 +199,29 @@ Using the times(N) modifier, or its aliases -- once, twice, never --
 allows you to create expectations that will be automatically checked by
 the test runner.
 
-Ensure fly('forward') gets called exactly three times
+Ensure fly("forward") gets called exactly three times
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args('forward')
-        .times(3))
+    flexmock(plane).should_receive("fly").with_args("forward").times(3)
 
-Ensure turn('east') gets called at least twice
+Ensure turn("east") gets called at least twice
 
 ::
 
-    (flexmock(plane)
-        .should_receive('turn')
-        .with_args('east')
-        .at_least().twice())
+    flexmock(plane).should_receive("turn").with_args("east").at_least().twice()
 
-Ensure land('airfield') gets called at most once
+Ensure land("airfield") gets called at most once
 
 ::
 
-    (flexmock(plane)
-        .should_receive('land')
-        .with_args('airfield')
-        .at_most().once())
+    flexmock(plane).should_receive("land").with_args("airfield").at_most().once()
 
-Ensure that crash('boom!') is never called
+Ensure that crash("boom!") is never called
 
 ::
 
-    (flexmock(plane)
-        .should_receive('crash')
-        .with_args('boom!')
-        .never())
+    flexmock(plane).should_receive("crash").with_args("boom!").never()
 
 Exceptions
 ----------
@@ -242,17 +230,13 @@ You can make the mocked method raise an exception instead of returning a value.
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .and_raise(BadWeatherException))
+    flexmock(plane).should_receive("fly").and_raise(BadWeatherException)
 
 Or you can add a message to the exception being raised
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .and_raise(BadWeatherException, 'Oh noes, rain!'))
+    flexmock(plane).should_receive("fly").and_raise(BadWeatherException, "Oh noes, rain!")
 
 
 Spies (proxies)
@@ -267,66 +251,49 @@ Matching specific arguments
 
 ::
 
-    (flexmock(plane)
-        .should_call('repair')
-        .with_args(wing, cockpit)
-        .once())
+    flexmock(plane).should_call("repair").with_args("wing", "cockpit").once()
 
 Matching any arguments
 
 ::
 
-    (flexmock(plane)
-        .should_call('turn')
-        .twice())
+    flexmock(plane).should_call("turn").twice()
 
 Matching specific return values
 
 ::
 
-    (flexmock(plane)
-        .should_call('land')
-        .and_return('landed!'))
+    flexmock(plane).should_call("land").and_return("landed!")
 
 Matching a regular expression
 
 ::
 
-    (flexmock(plane)
-        .should_call('land')
-        .and_return(re.compile('^la')))
+    flexmock(plane).should_call("land").and_return(re.compile("^la"))
 
 Match return values by class/type
 
 ::
 
-    (flexmock(plane)
-        .should_call('fly')
-        .and_return(str, object, None))
+    flexmock(plane).should_call("fly").and_return(str, object, None)
 
 Ensure that an appropriate exception is raised
 
 ::
 
-    (flexmock(plane)
-        .should_call('fly')
-        .and_raise(BadWeatherException))
+    flexmock(plane).should_call("fly").and_raise(BadWeatherException)
 
 Check that the exception message matches your expectations
 
 ::
 
-    (flexmock(plane)
-        .should_call('fly')
-        .and_raise(BadWeatherException, 'Oh noes, rain!'))
+    flexmock(plane).should_call("fly").and_raise(BadWeatherException, "Oh noes, rain!")
 
 Check that the exception message matches a regular expression
 
 ::
 
-    (flexmock(plane)
-        .should_call('fly')
-        .and_raise(BadWeatherException, re.compile('rain')))
+    flexmock(plane).should_call("fly").and_raise(BadWeatherException, re.compile("rain"))
 
 If either and_return() or and_raise() is provided, flexmock will
 verify that the return value matches the expected return value or
@@ -341,32 +308,31 @@ It's possible for the mocked method to return different values on successive cal
 
 ::
 
-    >>> flexmock(group).should_receive('get_member').and_return('user1').and_return('user2').and_return('user3')
+    >>> flexmock(group).should_receive("get_member").and_return("user1").and_return(
+        "user2"
+    ).and_return("user3")
     >>> group.get_member()
-    'user1'
+    "user1"
     >>> group.get_member()
-    'user2'
+    "user2"
     >>> group.get_member()
-    'user3'
+    "user3"
 
 Or use the short-hand form
 
 ::
 
-    (flexmock(group)
-        .should_receive('get_member')
-        .and_return('user1', 'user2', 'user3')
-        .one_by_one())
+    flexmock(group).should_receive("get_member").and_return(
+        "user1", "user2", "user3"
+    ).one_by_one()
 
 You can also mix return values with exception raises
 
 ::
 
-    (flexmock(group)
-        .should_receive('get_member')
-        .and_return('user1')
-        .and_raise(Exception)
-        .and_return('user2'))
+    flexmock(group).should_receive("get_member").and_return("user1").and_raise(
+        Exception
+    ).and_return("user2")
 
 Fake new instances
 ------------------
@@ -379,47 +345,43 @@ Your first option is to simply replace the class with a function.
 
 ::
 
-    (flexmock(some_module)
-        .should_receive('NameOfClass')
-        .and_return(fake_instance))
+    flexmock(some_module).should_receive("NameOfClass").and_return(fake_instance)
     # fake_instance can be created with flexmock as well
 
-The upside of this approach is that it works for both new-style and old-style
-classes. The downside is that you may run into subtle issues since the
-class has now been replaced by a function.
+The downside if this is that you may run into subtle issues since the class has now been replaced by a function.
 
-If you're dealing with new-style classes, flexmock offers another alternative using the `.new_instances()` method.
+Flexmock offers another alternative using the `.new_instances()` method.
 
 ::
 
-    >>> class Group(object): pass
-    >>> fake_group = flexmock(name='fake')
+    >>> class Group: pass
+    >>> fake_group = flexmock(name="fake")
     >>> flexmock(Group).new_instances(fake_group)
-    >>> Group().name == 'fake'
+    >>> Group().name == "fake"
     True
 
 It is also possible to return different fake objects in a sequence.
 
 ::
 
-    >>> class Group(object): pass
-    >>> fake_group1 = flexmock(name='fake')
-    >>> fake_group2 = flexmock(name='real')
+    >>> class Group: pass
+    >>> fake_group1 = flexmock(name="fake")
+    >>> fake_group2 = flexmock(name="real")
     >>> flexmock(Group).new_instances(fake_group1, fake_group2)
-    >>> Group().name == 'fake'
+    >>> Group().name == "fake"
     True
-    >>> Group().name == 'real'
+    >>> Group().name == "real"
     True
 
 Another approach, if you're familiar with how instance instatiation is done in Python, is to stub the `__new__` method directly.
 
 ::
 
-    >>> flexmock(Group).should_receive('__new__').and_return(fake_group)
+    >>> flexmock(Group).should_receive("__new__").and_return(fake_group)
     >>> # or, if you want to be even slicker
     >>> flexmock(Group, __new__=fake_group)
 
-In fact, the new_instances command is simply shorthand for `should_receive('__new__').and_return()` under the hood.
+In fact, the new_instances command is simply shorthand for `should_receive("__new__").and_return()` under the hood.
 
 Generators
 ----------
@@ -429,18 +391,18 @@ the mocked method into a generator that yields successive values.
 
 ::
 
-    >>> flexmock(plane).should_receive('flight_log').and_yield('take off', 'flight', 'landing')
+    >>> flexmock(plane).should_receive("flight_log").and_yield("take off", "flight", "landing")
     >>> for i in plane.flight_log():
-    >>>   print i
-    'take off'
-    'flight' 
-    'landing'
+    >>>     print i
+    "take off"
+    "flight" 
+    "landing"
 
 You can also use Python's builtin iter() function to generate an iterable return value.
 
 ::
 
-  flexmock(plane, flight_log=iter(['take off', 'flight', 'landing']))
+  flexmock(plane, flight_log=iter(["take off", "flight", "landing"]))
 
 In fact, the and_yield() modifier is just shorthand for should_receive().and_return(iter)
 under the hood.
@@ -462,38 +424,30 @@ flexmock does not enforce call order by default, but it's easy to do if you need
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args('forward')
-        .and_return('ok')
-        .ordered())
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args('up')
-        .and_return('ok')
-        .ordered())
+    flexmock(plane).should_receive("fly").with_args("forward").and_return("ok").ordered()
+    flexmock(plane).should_receive("fly").with_args("up").and_return("ok").ordered()
 
 The order of the flexmock calls is the order in which these methods will need to be
 called by the code under test.
 
 If method fly() above is called with the right arguments in the declared order things
-will be fine and both will return 'ok'.
-But trying to call fly('up') before fly('forward') will result in an exception.
+will be fine and both will return "ok".
+But trying to call fly("up") before fly("forward") will result in an exception.
 
 State Support
 -------------
 
 flexmock supports conditional method execution based on external state.
-Consider the rather contrived Radio class with the following methods:
+Consider the rather contrived `Radio` class with the following methods:
 
 ::
 
   >>> class Radio:
-  ...   is_on = False
-  ...   def switch_on(self): self.is_on = True
-  ...   def switch_off(self): self.is_on = False
-  ...   def select_channel(self): return None
-  ...   def adjust_volume(self, num): self.volume = num 
+  ...     is_on = False
+  ...     def switch_on(self): self.is_on = True
+  ...     def switch_off(self): self.is_on = False
+  ...     def select_channel(self): return None
+  ...     def adjust_volume(self, num): self.volume = num
   >>> radio = Radio()
 
 Now we can define some method call expectations dependent on the state of the radio:
@@ -501,8 +455,8 @@ Now we can define some method call expectations dependent on the state of the ra
 ::
 
   >>> flexmock(radio)
-  >>> radio.should_receive('select_channel').once().when(lambda: radio.is_on)
-  >>> radio.should_call('adjust_volume').once().with_args(5).when(lambda: radio.is_on)
+  >>> radio.should_receive("select_channel").once().when(lambda: radio.is_on)
+  >>> radio.should_call("adjust_volume").once().with_args(5).when(lambda: radio.is_on)
 
 
 Calling these while the radio is off will result in an error:
@@ -511,18 +465,13 @@ Calling these while the radio is off will result in an error:
 
   >>> radio.select_channel()
   Traceback (most recent call last):
-    File "<stdin>", line 1, in <module>
-    File "flexmock.py", line 674, in mock_method
-      (method, expectation._get_runnable()))
+    ...
   flexmock.StateError: select_channel expected to be called when condition is True
 
   >>> radio.adjust_volume(5)
   Traceback (most recent call last):
-    File "<stdin>", line 1, in <module>
-    File "flexmock.py", line 674, in mock_method
-      (method, expectation._get_runnable()))
+    ...
   flexmock.StateError: adjust_volume expected to be called when condition is True
-  Traceback (most recent call last):
 
 Turning the radio on will make things work as expected:
 
@@ -542,15 +491,13 @@ Let's say you have some code that looks something like the following:
 ::
 
     http = HTTP()
-    results = (http.get_url('http://www.google.com')
-                  .parse_html()
-                  .display_results())
+    results = http.get_url("http://www.google.com").parse_html().display_results()
 
 You could use flexmock to mock each of these method calls individually:
 
 ::
 
-    mock = flexmock(get_url=lambda: flexmock(parse_html=lambda: flexmock(display_results='ok')))
+    mock = flexmock(get_url=lambda: flexmock(parse_html=lambda: flexmock(display_results="ok")))
     flexmock(HTTP).new_instances(mock)
 
 But that looks really error prone and quite difficult to parse when
@@ -560,7 +507,7 @@ reading. Here's a better way:
 
     mock = flexmock()
     flexmock(HTTP).new_instances(mock)
-    mock.should_receive('get_url.parse_html.display_results').and_return('ok')
+    mock.should_receive("get_url.parse_html.display_results").and_return("ok")
 
 When using this short-hand, flexmock will create intermediate objects
 and expectations, returning the final one in the chain. As a result, any
@@ -576,8 +523,8 @@ the stub for display_results() because the one for save_results() overrides it:
 
 ::
 
-    flexmock(HTTP).should_receive('get_url.parse_html.display_results').and_return('ok')
-    flexmock(HTTP).should_receive('get_url.parse_html.save_results').and_return('ok')
+    flexmock(HTTP).should_receive("get_url.parse_html.display_results").and_return("ok")
+    flexmock(HTTP).should_receive("get_url.parse_html.save_results").and_return("ok")
 
 In this situation, you should identify the point where the chain starts to
 diverge and return a flexmock() object that handles all the "tail"
@@ -585,9 +532,9 @@ methods using the same object:
 
 ::
 
-    (flexmock(HTTP)
-        .should_receive('get_url.parse_html')
-        .and_return(flexmock(display_results='ok', save_results='ok')))
+    flexmock(HTTP).should_receive("get_url.parse_html").and_return(
+        flexmock(display_results="ok", save_results="ok")
+    )
 
 
 Replacing methods
@@ -599,9 +546,7 @@ based on provided arguments or a global value that changes between method calls.
 
 ::
 
-    (flexmock(plane)
-        .should_receive('set_speed')
-        .replace_with(lambda x: x == 5))
+    flexmock(plane).should_receive("set_speed").replace_with(lambda x: x == 5)
 
 There is also shorthand for this, similar to the shorthand for should_receive/and_return:
 
@@ -625,12 +570,11 @@ your mock or stub to just the specific invocation you are trying to replace:
 
 ::
 
-   mock = flexmock(sys.modules['builtins'])
-   mock.should_call('open')  # set the fall-through
-   (mock.should_receive('open')
-       .with_args('/your/file')
-       .and_return( flexmock(read=lambda: 'file contents') ))
-
+    mock = flexmock(__builtins__)
+    mock.should_call("open")  # set the fall-through
+    mock.should_receive("open").with_args("file_name").and_return(
+        flexmock(read=lambda: "some data")
+    )
 
 Expectation Matching
 ====================
@@ -640,34 +584,30 @@ arguments, including no arguments.
 
 ::
 
-    >>> flexmock(plane).should_receive('fly').and_return('ok')
+    >>> flexmock(plane).should_receive("fly").and_return("ok")
 
 Will be matched by any of the following:
 
 ::
 
     >>> plane.fly()
-    'ok'
-    >>> plane.fly('up')
-    'ok'
-    >>> plane.fly('up', 'down')
-    'ok'
+    "ok"
+    >>> plane.fly("up")
+    "ok"
+    >>> plane.fly("up", "down")
+    "ok"
 
 You can also match exactly no arguments 
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args())
+    flexmock(plane).should_receive("fly").with_args()
 
 Or match any single argument
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args(object))
+    flexmock(plane).should_receive("fly").with_args(object)
 
 :NOTE: In addition to exact values, you can match against the type or class of the argument.
 
@@ -675,18 +615,14 @@ Match any single string argument
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args(str))
+    flexmock(plane).should_receive("fly").with_args(str)
 
 Match the empty string using a compiled regular expression
 
 ::
 
-    regex = re.compile('^(up|down)$')
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args(regex))
+    regex = re.compile("^(up|down)$")
+    flexmock(plane).should_receive("fly").with_args(regex)
 
 Match any set of three arguments where the first one is an integer,
 second one is anything, and third is string 'notes'
@@ -694,9 +630,7 @@ second one is anything, and third is string 'notes'
 
 ::
 
-    (flexmock(plane)
-        .should_receive('repair')
-        .with_args(int, object, 'notes'))
+    flexmock(plane).should_receive("repair").with_args(int, object, "notes")
 
 And if the default argument matching based on types is not flexible enough,
 flexmock will respect matcher objects that provide a custom __eq__ method.
@@ -710,13 +644,14 @@ use its __eq__ method when comparing the arguments at runtime.
 
 ::
 
-    class NumpyArrayMatcher(object):
-        def __init__(self, array): self.array = array
-        def __eq__(self, other): return all(other == self.array)
+    class NumpyArrayMatcher:
+        def __init__(self, array):
+            self.array = array
 
-    (flexmock(obj)
-        .should_receive('function')
-        .with_args(NumpyArrayMatcher(array1)))
+        def __eq__(self, other):
+            return all(other == self.array)
+
+    flexmock(obj).should_receive("function").with_args(NumpyArrayMatcher(array1))
 
 The above approach will work for any objects that choose not to return proper
 boolean comparison values, or if you simply find the default equality and 
@@ -727,8 +662,8 @@ method differentiated by arguments.
 
 ::
 
-    >>> flexmock(plane).should_receive('fly').and_return('ok')
-    >>> flexmock(plane).should_receive('fly').with_args('up').and_return('bad')
+    >>> flexmock(plane).should_receive("fly").and_return("ok")
+    >>> flexmock(plane).should_receive("fly").with_args("up").and_return("bad")
 
 Try to excecute plane.fly() with any, or no, arguments as defined by the first
 flexmock call will return the first value.
@@ -736,17 +671,17 @@ flexmock call will return the first value.
 ::
 
     >>> plane.fly()
-    'ok'
-    >>> plane.fly('forward', 'down')
-    'ok'
+    "ok"
+    >>> plane.fly("forward", "down")
+    "ok"
 
 But! If argument values match the more specific flexmock call the function
 will return the other return value.
 
 ::
 
-    >>> plane.fly('up')
-    'bad'
+    >>> plane.fly("up")
+    "bad"
 
 The order of the expectations being defined is significant, with later
 expectations having higher precedence than previous ones. Which means
@@ -763,17 +698,11 @@ If using with_args(), place it before should_return(), and_raise() and and_yield
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .with_args('up', 'down')
-        .and_return('ok'))
+    flexmock(plane).should_receive("fly").with_args("up", "down").and_return("ok")
 
 If using the times() modifier (or its aliases: once, twice, never), place them at
 the end of the flexmock statement:
 
 ::
 
-    (flexmock(plane)
-        .should_receive('fly')
-        .and_return('ok')
-        .once())
+    flexmock(plane).should_receive("fly").and_return("ok").once()


### PR DESCRIPTION
I updated all  code examples in docs:

- Consistent formatting with our code.
- Removed Mox mocking library comparison because Mox is not maintained anymore.
- Some other small improvements.

Rendered documentation with the changes is here:
https://flexmock.readthedocs.io/en/docs-update-code-examples/

Alternatively check mkdocs branch which is based on these changes and contains some more code example improvements:
https://flexmock.readthedocs.io/en/docs-use-mkdocs/