### PR TITLE
Test stable Python 3.10 in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          ["pypy-3.6", "pypy-3.7", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+          [
+            "pypy-3.6",
+            "pypy-3.7",
+            "3.6",
+            "3.7",
+            "3.8",
+            "3.9",
+            "3.10",
+            # "3.11-dev", disabled until test tools support 3.11
+          ]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +51,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Install Poetry
         run: pip install poetry

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Unreleased
 Added
 #####
 
-- Add Python 3.8, 3.9, 3.10 support.
+- Add Python 3.8, 3.9, and 3.10 support.
 - Add type annotations.
 
 Changed

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = pypy{3.6,3.7}-pytest-latest, py{36,37,38,39}-pytest{5,6}, py310-pytest-latest
+envlist = pypy{3.6,3.7}-pytest-latest, py{36,37,38,39}-pytest{5,6}, py310-pytest6, py311-pytest-latest
 
 [gh-actions]
 python =
@@ -11,6 +11,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 deps =


### PR DESCRIPTION
Test stable Python 3.10 in Github Actions. Python 3.11 tests are disabled until tox supports 3.11.
