### PR TITLE
Prepare 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Types of changes:
 - **Infrastructure**: Changes in build or deployment infrastructure.
 - **Documentation**: Changes in documentation.
 
-## Unreleased
+## Release 0.11.0
 
 ### Added
 
@@ -25,6 +25,7 @@ Types of changes:
   The hack that allowed flexmock to be imported directly using `import flexmock` did not work well with static analysis tools.
 - Many error messages have been improved.
 - Undocumented methods `Expectation.reset`, `Expectation.verify`, and `Expectation.match_args` that were unintentionally left public are now private methods.
+- Undocumented attributes in `Mock` and `Expectation` are now private. These attributes were never meant to be accessed directly.
 
 ### Removed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,6 @@
 include *.py
-include CHANGELOG.rst
+include CHANGELOG.md
 include LICENSE
 include README.md
 recursive-include tests *py
-include docs/conf.py
-include docs/Makefile
-recursive-include docs *.rst
+recursive-include docs *.md

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ flexmock(Train).should_call("get_tickets").at_most().times(3)
 # Make sure that a method is never called with specific arguments
 flexmock(Train).should_call("set_destination").with_args("Helsinki").never()
 
-# Here is a more complex spy example that uses multiple features like argument type and exception matching
-flexmock(Train).should_call("set_destination").with_args(str, int).and_raise(AttributeError).once()
+# More complex example with features like argument type and exception matching
+flexmock(Train).should_call("crash").with_args(str, int).and_raise(AttributeError).once()
 ```
 
 See more examples in the documentation.

--- a/fedora/python-flexmock.spec
+++ b/fedora/python-flexmock.spec
@@ -44,7 +44,7 @@ BuildRequires:  python3-setuptools
 
 %files -n python3-flexmock
 %license LICENSE
-%doc README.md CHANGELOG.rst docs/
+%doc README.md CHANGELOG.md docs/
 %{python3_sitelib}/*
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,11 @@ classifiers = [
 ]
 include = [
     "CHANGELOG.md",
-    "docs/conf.py",
-    "docs/Makefile",
-    "docs/**/*.rst",
+    "docs/**/*.md",
     "LICENSE",
     "README.md",
     "src/**/*.py",
-    "tests/**/*.{py,sh}",
+    "tests/**/*.py",
 ]
 packages = [{ include = "flexmock", from = "src" }]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ include = [
 packages = [{ include = "flexmock", from = "src" }]
 
 [tool.poetry.urls]
-"Changes" = "https://github.com/flexmock/flexmock/blob/master/CHANGELOG.rst"
+"Changes" = "https://flexmock.readthedocs.io/en/latest/changelog/"
 "Source Code" = "https://github.com/flexmock/flexmock"
 "Issue Tracker" = "https://github.com/flexmock/flexmock/issues"
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://flexmock.readthedocs.io/",
     project_urls={
         "Documentation": "https://flexmock.readthedocs.io/",
-        "Changes": "https://github.com/flexmock/flexmock/blob/master/CHANGELOG.rst",
+        "Changes": "https://flexmock.readthedocs.io/en/latest/changelog/",
         "Source Code": "https://github.com/flexmock/flexmock",
         "Issue Tracker": "https://github.com/flexmock/flexmock/issues",
     },


### PR DESCRIPTION
Version number has already been updated in `pyproject.toml` and `setup.py`. Is there something else you think we should mention in the changelog?

I made a test release to PyPi [flexmock - test PyPi](https://test.pypi.org/project/flexmock/0.11.4/). If you want to test the release you can install it with this command:
```
pip install --index-url https://test.pypi.org/simple/ -U flexmock
```