### PR TITLE
Fix mock is not callable

### DIFF
--- a/src/flexmock/_api.py
+++ b/src/flexmock/_api.py
@@ -76,6 +76,14 @@ class Mock:
     ) -> None:
         pass
 
+    def __call__(self, *args: Any, **kwargs: Any) -> "Mock":
+        """Make mocks callable with and without parentheses.
+
+        If `Mock` is not callable, it is difficult to mock attributes that
+        should work with and without parentheses.
+        """
+        return self
+
     def __iter__(self) -> Iterator[Any]:
         """Makes the mock object iterable.
 

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -566,6 +566,16 @@ class RegularClass:
         assert_equal(saved1, user.get_name)
         assert_equal(saved2, group.get_name)
 
+    def test_flexmock_stubs_are_callable(self):
+        stub = flexmock()
+        mocked = flexmock()
+        mocked.should_receive("create").twice()
+        stub.tickets = mocked
+        # stub.tickets should work with and without parentheses
+        stub.tickets().create()
+        stub.tickets.create()
+        self._tear_down()
+
     def test_flexmock_respects_at_least_when_called_less_than_requested(self):
         mock = flexmock(name="temp")
         mock.should_receive("method_foo").and_return("bar").at_least().twice()


### PR DESCRIPTION
Removing `__call__` from `Mock` broke tests where an attribute that was replaced should be callable with and without parentheses.

One example of this kind of behavior is in Zenpy package where the following will search for a ticket with a specific ID:

```python
client.tickets(id=some_ticket_id)
```

To update the ticket, `tickets` is accessed without parentheses:

```python
client.tickets.update(ticket)
```

If `Mock` is not callable, it is difficult to mock `client` in this case. Allowing only call with parentheses can be achieved using `should_receive().and_return()`.

`client.tickets` works with and without parentheses:
```python
client = flexmock()
mocked = flexmock()
mocked.should_receive("create")
client.tickets = mocked
client.tickets().create()
client.tickets.create()
```

`client.tickets` works only with parentheses:
```python
client = flexmock()
mocked = flexmock()
mocked.should_receive("create")
client.should_receive("tickets").and_return(mocked)
client.tickets().create()
```

Closes #98