### PR TITLE
Fix Zope testrunner integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Types of changes:
 - **Infrastructure**: Changes in build or deployment infrastructure.
 - **Documentation**: Changes in documentation.
 
+## Release 0.11.1
+
+### Fixed
+
+- Fix Zope testrunner integration is broken.
+
+### Infrastructure
+
+- Run tests with Zope testrunner using tox.
+
 ## Release 0.11.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexmock"
-version = "0.11.0"
+version = "0.11.1"
 description = "flexmock is a testing library for Python that makes it easy to create mocks, stubs and fakes."
 authors = ["Slavek Kabrda", "Herman Sheremetyev"]
 maintainers = [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as file:
 
 setup(
     name="flexmock",
-    version="0.11.0",
+    version="0.11.1",
     author="Slavek Kabrda, Herman Sheremetyev",
     author_email="slavek@redhat.com",
     url="https://flexmock.readthedocs.io/",

--- a/src/flexmock/_integrations.py
+++ b/src/flexmock/_integrations.py
@@ -178,7 +178,11 @@ with suppress(ImportError):
 with suppress(ImportError):
     from zope import testrunner  # pylint: disable=no-name-in-module
 
-    _patch_test_result(testrunner.runner.TestResult)
+    try:
+        _patch_test_result(testrunner.runner.TestResult)
+    except AttributeError:
+        # testrunner.runner is only available when tests are executed with zope.testrunner
+        pass
 
 
 # Hook into subunit.

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ deps =
     pytest6: pytest>=6.0,<7.0
     pytest-latest: pytest
     twisted
+    zope.testrunner
 commands =
     python -m unittest tests/flexmock_test.py
     python -c "from twisted.scripts.trial import run; run();" tests/flexmock_test.py
+    zope-testrunner  --test-path=./ --test-file-pattern=flexmock_test --verbose
     pytest tests/flexmock_pytest_test.py


### PR DESCRIPTION
Fixed Zope testrunner integration and added Zope testrunner to tox.

`zope.testrunner.runner` is not available outside the testrunner so it raises an exception when zope is installed but test runner is not running.

Closes #100 