### PR TITLE
Fix subunit integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ Types of changes:
 
 ## Unreleased
 
+### Fixed
+
+- Fix subunit testrunner integration is broken.
+
 ### Infrastructure
 
-- Run tests with testtools and doctest testrunners using tox.
+- Run tests with testtools, subunit, and doctest testrunners using tox.
 
 ### Documentation
 

--- a/src/flexmock/_integrations.py
+++ b/src/flexmock/_integrations.py
@@ -72,7 +72,7 @@ def _patch_add_success(klass: Type[unittest.TextTestResult]) -> None:
     """
 
     @wraps(klass.addSuccess)
-    def decorated(self: unittest.TextTestResult, _test: unittest.TestCase) -> None:
+    def decorated(self: unittest.TextTestResult, _test: unittest.TestCase, **_kwargs: Any) -> None:
         self._pre_flexmock_success = True  # type: ignore
 
     if klass.addSuccess is not decorated:
@@ -193,6 +193,7 @@ with suppress(ImportError):
     import subunit
 
     _patch_test_result(subunit.TestProtocolClient)
+    _patch_test_result(subunit.test_results.TestResultDecorator)
 
 
 # Hook into twisted.

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -48,8 +48,40 @@ class BadWeatherException(Exception):
     pass
 
 
+class TestDoctestTeardown:
+    """Test doctest runner teardown."""
+
+    def test_flexmock_teardown_works_with_doctest_part_1(self):
+        """Part 1
+
+        Examples:
+            Part 1:
+
+            >>> from flexmock import flexmock
+            >>> flexmock().should_receive("method1").ordered()
+            <flexmock._api.Expectation object at ...>
+        """
+
+    def test_flexmock_teardown_works_with_doctest_part_2(self):
+        """Raises CallOrderError if flexmock teardown is not automatically called
+        after test part 1 above.
+
+        Examples:
+            Part 2:
+
+            >>> from flexmock import flexmock
+            >>> mock = flexmock().should_receive("method2").ordered().mock()
+            >>> mock.method2()
+        """
+
+
 if __name__ == "__main__":
-    results = doctest.testmod(
+    results1 = doctest.testmod(
+        sys.modules[__name__],  # current module
+        optionflags=doctest.ELLIPSIS,
+    )
+
+    results2 = doctest.testmod(
         _api,
         extraglobs={
             "Plane": Plane,
@@ -58,4 +90,5 @@ if __name__ == "__main__":
         },
         optionflags=doctest.ELLIPSIS,
     )
-    sys.exit(results.failed)
+
+    sys.exit(results1.failed + results2.failed)

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -91,4 +91,4 @@ if __name__ == "__main__":
         optionflags=doctest.ELLIPSIS,
     )
 
-    sys.exit(results1.failed + results2.failed)
+    sys.exit(bool(results1.failed + results2.failed))

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -26,6 +26,17 @@ def test_runtest_hook_with_fixture_for_pytest(runtest_hook_fixture):
     runtest_hook_fixture.foo()
 
 
+def test_flexmock_teardown_works_with_pytest_part1():
+    flexmock().should_receive("method1").ordered()
+
+
+def test_flexmock_teardown_works_with_pytest_part2():
+    mock = flexmock().should_receive("method2").ordered().mock()
+    # Raises CallOrderError if flexmock teardown is not automatically called
+    # after test part 1 above
+    mock.method2()
+
+
 class TestForPytest(test_flexmock.RegularClass):
     def test_class_level_test_for_pytest(self):
         flexmock(foo="bar").should_receive("foo").once()

--- a/tests/test_testtools.py
+++ b/tests/test_testtools.py
@@ -1,5 +1,5 @@
 """Test testtools integration."""
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,no-self-use
 from contextlib import suppress
 
 from testtools import TestCase
@@ -36,3 +36,12 @@ class TestFlexmock(TestCase):
         self.assertThat(mocked.method(), Equals(1))
         with suppress(exceptions.MethodCallError):
             flexmock_teardown()
+
+    def test_flexmock_teardown_works_with_testtools_part1(self):
+        flexmock().should_receive("method1").ordered()
+
+    def test_flexmock_teardown_works_with_testtools_part2(self):
+        mock = flexmock().should_receive("method2").ordered().mock()
+        # Raises CallOrderError if flexmock teardown is not automatically called
+        # after test part 1 above
+        mock.method2()

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,16 @@ deps =
     twisted
     zope.testrunner
     testtools
+    python-subunit
+
+whitelist_externals=
+    sh
+
 commands =
     python -m unittest tests/test_flexmock.py
     python tests/test_doctest.py
     python -c "from twisted.scripts.trial import run; run();" tests/test_flexmock.py
     zope-testrunner  --test-path=./ --test-file-pattern=test_flexmock --verbose
     python -m testtools.run --verbose tests/test_testtools.py
+    sh -c 'python -m subunit.run tests/test_flexmock.py | subunit2pyunit'
     pytest tests/test_pytest.py


### PR DESCRIPTION
I added tests for subunit integration and noticed it was broken. Patching `subunit.test_results.TestResultDecorator` seems to fix the integration.

Other changes:
- Test that flexmock teardown works with doctest, pytest and testtools.

Related issue #68 