### PR TITLE
Add python_files configuration for pytest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
           poetry run coverage run --parallel-mode --source flexmock -m unittest tests/test_flexmock.py
           poetry run coverage run --parallel-mode --source flexmock tests/test_unittest.py
           poetry run coverage run --parallel-mode --source flexmock tests/test_doctest.py
-          poetry run coverage run --parallel-mode --source flexmock -m pytest tests/test_pytest.py
+          poetry run coverage run --parallel-mode --source flexmock -m pytest
           poetry run coverage combine
           poetry run coverage xml
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ pytest:
 	@printf '\n\n*****************\n'
 	@printf '$(color)Running pytest$(off)\n'
 	@printf '*****************\n'
-	pytest tests/test_pytest.py
+	pytest
 
 .PHONY: unittest
 unittest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,3 +117,7 @@ no_implicit_optional = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 ignore_errors = true
+
+[tool.pytest.ini_options]
+python_files = ["test_pytest.py"]
+xfail_strict = true


### PR DESCRIPTION
Pytest should only execute tests in `test_pytest.py` file. This change instructs pytest to ignore any other test files/modules.

I also added `xfail_strict` setting so that tests marked with `xfail` will fail the test run if they are actually successful.

Closes #119 