### PR TITLE
Add warning to docs about new_instances method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Types of changes:
 - Remove documentation and test files from wheels build.
 - Re-organize unit tests.
 
+### Documentation
+
+- Add a warning about the usage of `.new_instances()` method in the documentation.
+
 ## Release 0.11.2
 
 ### Fixed

--- a/docs/advanced/new_instances.md
+++ b/docs/advanced/new_instances.md
@@ -15,6 +15,13 @@ now been replaced by a function.
 
 Flexmock offers another alternative using the `.new_instances()` method:
 
+!!!warning
+
+    Usage of `.new_instances()` method is discouraged due to a bug in CPython
+    which prevents proper teardown of the mock. Due to this bug, the mock leaks
+    into other tests and can prevent creating new instances of the class. More
+    information in [issue #16](https://github.com/flexmock/flexmock/issues/16).
+
 ```python
 >>> class Group: pass
 >>> fake_group = flexmock(name="fake")


### PR DESCRIPTION
Since we dropped Python 2 support, `new_instances` method can't be used in CPython without hitting the bug described in issue #16. The bug doesn't seem to affect PyPy.

I added a warning about the usage of `new_instances` method in docs:

![image](https://user-images.githubusercontent.com/25169984/152668328-06ddb57d-b235-4324-a498-c968c4e8e82f.png)

Before we remove or deprecate this method, I think we should first think about some alternative way to fake new instances.