### PR TITLE
Add tox.ini to sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Types of changes:
 
 - Add Python 3.12 support.
 
+### Changed
+
+- Add tox.ini to sdist to make the downstream testing easier.
+
 ### Removed
 
 - Drop Python 3.6 support.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include *.py
 include CHANGELOG.md
 include LICENSE
 include README.md
+include tox.ini
 recursive-include tests *py
 recursive-include docs *.md
 include docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ include = [
     { path = "docs/**/*.md", format = "sdist" },
     { path = "LICENSE", format = "sdist" },
     { path = "README.md", format = "sdist" },
+    { path = "tox.ini", format = "sdist" },
     { path = "tests/**/*.py", format = "sdist" },
     { path = "docs/conf.py", format = "sdist" },
     { path = "docs/toctree.rst", format = "sdist" },


### PR DESCRIPTION
Add tox.ini to sdist to make the downstream testing easier. Closes #136.