### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-with open("README.md", "r", encoding="utf-8") as file:
+with open("README.md", encoding="utf-8") as file:
     long_description = file.read()
 
 VERSION = "0.12.0"


### PR DESCRIPTION
Filer all code over `pyupgrade --py38-plus`.