### PR TITLE
Combine `with_args` with `__new__`

### DIFF
--- a/tests/features/mocking.py
+++ b/tests/features/mocking.py
@@ -804,6 +804,16 @@ class MockingTestCase:
         flexmock(instance).should_receive("method").with_args("stuff")
         instance.method("stuff")
 
+    def test_with_args_scoped_mock(self):
+        class FooClass:
+            def method(self, arg):
+                return arg
+
+        flexmock(FooClass).should_receive("method").with_args("override").and_return("method override").once()
+        instance = FooClass()
+        assert instance.method("override") == "method override"
+        assert instance.method("original") == "original"
+
     def test_calling_with_keyword_args_matches_mock_with_positional_args(self):
         class FooClass:
             def method(self, arg1, arg2, arg3):

--- a/tests/features/mocking.py
+++ b/tests/features/mocking.py
@@ -814,6 +814,24 @@ class MockingTestCase:
         assert instance.method("override") == "method override"
         assert instance.method("original") == "original"
 
+    def test_with_args_on_new_constructor(self):
+        class FooClass:
+            def __init__(self, arg):
+                self.arg = arg
+
+            def method(self):
+                return self.arg
+
+        fake_Foo = flexmock()
+        fake_Foo.should_receive("method").and_return("method override")
+        flexmock(FooClass).should_receive("__new__").with_args("override").and_return(fake_Foo)
+        instance_mocked = FooClass("override")
+        assert isinstance(instance_mocked, Mock)
+        assert instance_mocked.method() == "method override"
+        instance_original = FooClass("original")
+        assert isinstance(instance_original, FooClass)
+        assert instance_original.method() == "original"
+
     def test_calling_with_keyword_args_matches_mock_with_positional_args(self):
         class FooClass:
             def method(self, arg1, arg2, arg3):


### PR DESCRIPTION
It seems the core issue is that `with_args` does not behave as a `when`, and thus it fails to give back control to the original caller when needing to mock only specific instances. I have added 2 test cases to illustrate the issue.

I was considering if this is a user issue, but how could one use `when` in combination with `__new__`? How would one access the `args`/`kwargs` passed to that function? Actually even when using `when` it seems to be producing errors when it arrives at:
https://github.com/flexmock/flexmock/blob/14812a8fd3fbb0b1093e6ff5ab162faefe9d07c2/src/flexmock/_api.py#L479-L482

The test case looks fishy too, it should not be raising exceptions when `when` is not *yet* satisfied:
https://github.com/flexmock/flexmock/blob/14812a8fd3fbb0b1093e6ff5ab162faefe9d07c2/tests/features/conditional.py#L35-L46