### PR TITLE
Fix teardown for mocking of derived class methods

### DIFF
--- a/src/flexmock/_api.py
+++ b/src/flexmock/_api.py
@@ -531,7 +531,10 @@ def flexmock_teardown() -> None:
     classes = []
     for mock_object, expectations in FlexmockContainer.flexmock_objects.items():
         saved[mock_object] = expectations[:]
-        for expectation in expectations:
+        # Reset the expectations in reversed order to ensure everything is restored to
+        # its original form even if setting consequent expectations on the same object
+        # operates on top of previous expectation and not on original object.
+        for expectation in reversed(expectations):
             expectation._reset()
         for expectation in expectations:
             # Remove method type attributes set by flexmock. This needs to be done after

--- a/tests/features/derived.py
+++ b/tests/features/derived.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=missing-docstring,no-member
 from flexmock import exceptions, flexmock
+from flexmock._api import flexmock_teardown
 from tests.some_module import DerivedClass, SomeClass
 from tests.utils import assert_raises
 
@@ -128,3 +129,19 @@ class DerivedTestCase:
         ).once()  # should be twice
         assert DerivedClass().static_method_with_args(4) == 4
         assert DerivedClass.static_method_with_args(4) == 4
+
+    def test_multi_mock_class_method_on_derived_class_is_properly_torn_down(self):
+        flexmock(DerivedClass).should_receive("class_method_with_args").with_args(1).once()
+        DerivedClass.class_method_with_args(1)
+
+        flexmock(DerivedClass).should_receive("class_method_with_args").with_args(2).once()
+        DerivedClass.class_method_with_args(2)
+
+        flexmock(DerivedClass).should_receive("class_method_with_args").with_args(3).once()
+        DerivedClass.class_method_with_args(3)
+
+        # Run teardown manually to allow this test case to be contained in single test
+        flexmock_teardown()
+
+        flexmock(DerivedClass).should_receive("class_method_with_args").with_args(4).once()
+        DerivedClass.class_method_with_args(4)


### PR DESCRIPTION
I know this is just a hotfix but it is better than nothing

Fixes #139