### PR TITLE
Update `on_raise` type annotation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,23 +33,23 @@ make lint
 
 CI pipeline also runs tests using all the supported Python versions. You can use Tox if you want to run these tests yourself, but first you need to have all different Python versions available in your local system.
 
-One option is to use [Pyenv](https://github.com/pyenv/pyenv) to manage different Python versions. For example, if you would want to run the test suite using Python versions 3.6 and 3.7, you can install the needed Python versions with the following commands:
+One option is to use [Pyenv](https://github.com/pyenv/pyenv) to manage different Python versions. For example, if you would want to run the test suite using Python versions 3.8 and 3.9, you can install the needed Python versions with the following commands:
 
 ```
-pyenv install 3.6.14
-pyenv install 3.7.11
+pyenv install 3.8.20
+pyenv install 3.9.21
 ```
 
 After the installation, you can make the installed Python versions available globally:
 
 ```
-pyenv global 3.6.14 3.7.11
+pyenv global 3.8.20 3.9.21
 ```
 
 Finally, you can run Tox and it should discover the installed Python version automatically:
 
 ```
-tox -e py36,py37
+tox -e py38,py39
 ```
 
 You can omit the `-e` argument if you want to run the tests against all supported Python versions. If everything works, the output should be something similar to this:
@@ -57,8 +57,8 @@ You can omit the `-e` argument if you want to run the tests against all supporte
 ```
 ...
 __________ summary __________
-  py36: commands succeeded
-  py37: commands succeeded
+  py38: commands succeeded
+  py39: commands succeeded
   congratulations :)
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Flexmock is a testing library for Python that makes it easy to create mocks, stu
 - **Simple and intuitive**: Declarations are structured to read more like English sentences than API calls, so they are easy to learn and use.
 - **Fully type annotated**: External API is fully type annotated so it works great with static analysis tools and editor auto-completion.
 - **Integrations with test runners**: Integrates seamlessly with all major test runners like unittest, doctest, and pytest.
-- **Python 3.6+ and PyPy3**: Extensively tested to work with latest Python versions.
+- **Python 3.8+ and PyPy3**: Extensively tested to work with latest Python versions.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ build-backend = "poetry.core.masonry.api"
 [tool.pylint.MASTER]
 load-plugins = ["pylint.extensions.docstyle", "pylint.extensions.typing"]
 
+[tool.pylint.main]
+py-version = "3.8.0"
+
 [tool.pylint.messages_control]
 disable = [
     "too-many-instance-attributes",

--- a/src/flexmock/_api.py
+++ b/src/flexmock/_api.py
@@ -6,7 +6,7 @@ import re
 import sys
 import types
 from types import BuiltinMethodType, TracebackType
-from typing import Any, Callable, Dict, Iterator, List, NoReturn, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Iterator, List, NoReturn, Optional, Tuple, Type, Union
 
 from flexmock.exceptions import (
     CallOrderError,
@@ -33,7 +33,9 @@ class ReturnValue:
     """ReturnValue"""
 
     def __init__(
-        self, value: Optional[Any] = None, raises: Optional[Type[BaseException]] = None
+        self,
+        value: Optional[Any] = None,
+        raises: Optional[Union[Type[BaseException], BaseException]] = None,
     ) -> None:
         self.value = value
         self.raises = raises
@@ -500,7 +502,7 @@ class Mock:
                     args = return_value.value
                     assert isinstance(args, dict)
                     raise return_value.raises(*args["kargs"], **args["kwargs"])
-                raise return_value.raises  # pylint: disable=raising-bad-type
+                raise return_value.raises
             return return_value.value
 
         def mock_method(runtime_self: Any, *kargs: Any, **kwargs: Any) -> Any:
@@ -1121,7 +1123,9 @@ class Expectation:
         self._runnable = func
         return self
 
-    def and_raise(self, exception: Type[BaseException], *args: Any, **kwargs: Any) -> "Expectation":
+    def and_raise(
+        self, exception: Union[Type[BaseException], BaseException], *args: Any, **kwargs: Any
+    ) -> "Expectation":
         """Specifies the exception to be raised when this expectation is met.
 
         Args:


### PR DESCRIPTION
Fix an issue with the type of the first argument of `and_raise` being incorrect.

It was marked as `type[BaseException]` but it's fine and supported to pass a `BaseException` instance directly (See [test case](https://github.com/flexmock/flexmock/blob/f15f8933e9216dc493acaaa46f6282e9739810df/tests/features/spying.py#L163) and [handler](https://github.com/flexmock/flexmock/blob/f15f8933e9216dc493acaaa46f6282e9739810df/src/flexmock/_api.py#L503))

I've also updated the contributing guide that was still referencing unsupported python versions. 

PS: This issue would have been flagged with mypy in tests but it's disabled (and was flagged by pylint but the error silenced)
> error: Argument 1 to "and_raise" of "Expectation" has incompatible type "RuntimeError"; expected "type[BaseException]"  [arg-type]

I'll submit a followup PR activating mypy in tests and adding type annotations.