### PR TITLE
Prepare v0.12.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ Types of changes:
 
 -
 
+## Release 0.12.2
+
+### Fixed
+
+- Fix typing of `and_raise` (exception instances are allowed).
+- Fix teardown for spying on derived class methods.
+
+### Documentation
+
+- Remove python 3.6 mentions and add py-version config to pylint.
+
 ## Release 0.12.1
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexmock"
-version = "0.12.1"
+version = "0.12.2"
 description = "flexmock is a testing library for Python that makes it easy to create mocks, stubs and fakes."
 authors = ["Slavek Kabrda", "Herman Sheremetyev"]
 maintainers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 with open("README.md", encoding="utf-8") as file:
     long_description = file.read()
 
-VERSION = "0.12.1"
+VERSION = "0.12.2"
 
 setup(
     name="flexmock",


### PR DESCRIPTION
Prepare v0.12.2 release with a couple of recently merged fixes. Next minor release could drop support for deprecated Python 3.8 version.